### PR TITLE
60 authsession gc

### DIFF
--- a/rsidmd/Cargo.toml
+++ b/rsidmd/Cargo.toml
@@ -34,7 +34,7 @@ lru = "0.1"
 
 tokio = "0.1"
 futures = "0.1"
-uuid = { version = "0.7", features = ["serde", "v4"] }
+uuid = { version = "0.7", features = ["serde", "v4", "v1"] }
 serde = "1.0"
 serde_cbor = "0.10"
 serde_json = "1.0"

--- a/rsidmd/Cargo.toml
+++ b/rsidmd/Cargo.toml
@@ -34,7 +34,7 @@ lru = "0.1"
 
 tokio = "0.1"
 futures = "0.1"
-uuid = { version = "0.7", features = ["serde", "v4", "v1"] }
+uuid = { version = "0.7", features = ["serde", "v4" ] }
 serde = "1.0"
 serde_cbor = "0.10"
 serde_json = "1.0"

--- a/rsidmd/src/lib/config.rs
+++ b/rsidmd/src/lib/config.rs
@@ -16,6 +16,7 @@ pub struct Configuration {
     pub maximum_request: usize,
     pub secure_cookies: bool,
     pub cookie_key: [u8; 32],
+    pub server_id: [u8; 6],
     pub integration_test_config: Option<Box<IntegrationTestConfig>>,
 }
 
@@ -32,10 +33,12 @@ impl Configuration {
             // TODO #63: default true in prd
             secure_cookies: if cfg!(test) { false } else { true },
             cookie_key: [0; 32],
+            server_id: [0; 6],
             integration_test_config: None,
         };
         let mut rng = StdRng::from_entropy();
         rng.fill(&mut c.cookie_key);
+        rng.fill(&mut c.server_id);
         c
     }
 

--- a/rsidmd/src/lib/config.rs
+++ b/rsidmd/src/lib/config.rs
@@ -1,5 +1,6 @@
 use rand::prelude::*;
 use std::path::PathBuf;
+use crate::utils::SID;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct IntegrationTestConfig {
@@ -16,7 +17,7 @@ pub struct Configuration {
     pub maximum_request: usize,
     pub secure_cookies: bool,
     pub cookie_key: [u8; 32],
-    pub server_id: [u8; 6],
+    pub server_id: SID,
     pub integration_test_config: Option<Box<IntegrationTestConfig>>,
 }
 
@@ -33,7 +34,7 @@ impl Configuration {
             // TODO #63: default true in prd
             secure_cookies: if cfg!(test) { false } else { true },
             cookie_key: [0; 32],
-            server_id: [0; 6],
+            server_id: [0; 4],
             integration_test_config: None,
         };
         let mut rng = StdRng::from_entropy();

--- a/rsidmd/src/lib/config.rs
+++ b/rsidmd/src/lib/config.rs
@@ -1,6 +1,6 @@
+use crate::utils::SID;
 use rand::prelude::*;
 use std::path::PathBuf;
-use crate::utils::SID;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct IntegrationTestConfig {

--- a/rsidmd/src/lib/constants.rs
+++ b/rsidmd/src/lib/constants.rs
@@ -6,6 +6,8 @@ pub static PURGE_TIMEOUT: u64 = 60;
 // For production, 1 hour.
 #[cfg(not(test))]
 pub static PURGE_TIMEOUT: u64 = 3600;
+// 2 minute auth session window.
+pub static AUTH_SESSION_TIMEOUT: u64 = 300;
 
 pub static STR_UUID_ADMIN: &'static str = "00000000-0000-0000-0000-000000000000";
 pub static STR_UUID_ANONYMOUS: &'static str = "00000000-0000-0000-0000-ffffffffffff";

--- a/rsidmd/src/lib/constants.rs
+++ b/rsidmd/src/lib/constants.rs
@@ -6,7 +6,7 @@ pub static PURGE_TIMEOUT: u64 = 60;
 // For production, 1 hour.
 #[cfg(not(test))]
 pub static PURGE_TIMEOUT: u64 = 3600;
-// 2 minute auth session window.
+// 5 minute auth session window.
 pub static AUTH_SESSION_TIMEOUT: u64 = 300;
 
 pub static STR_UUID_ADMIN: &'static str = "00000000-0000-0000-0000-000000000000";

--- a/rsidmd/src/lib/core.rs
+++ b/rsidmd/src/lib/core.rs
@@ -274,6 +274,7 @@ fn setup_backend(config: &Configuration) -> Result<Backend, OperationError> {
 fn setup_qs_idms(
     audit: &mut AuditScope,
     be: Backend,
+    sid: [u8; 6],
 ) -> Result<(QueryServer, IdmServer), OperationError> {
     // Create "just enough" schema for us to be able to load from
     // disk ... Schema loading is one time where we validate the
@@ -301,7 +302,7 @@ fn setup_qs_idms(
 
     // We generate a SINGLE idms only!
 
-    let idms = IdmServer::new(query_server.clone());
+    let idms = IdmServer::new(query_server.clone(), sid);
 
     Ok((query_server, idms))
 }
@@ -403,7 +404,7 @@ pub fn recover_account_core(config: Configuration, name: String, password: Strin
         }
     };
     // setup the qs - *with* init of the migrations and schema.
-    let (_qs, idms) = match setup_qs_idms(&mut audit, be) {
+    let (_qs, idms) = match setup_qs_idms(&mut audit, be, config.server_id.clone()) {
         Ok(t) => t,
         Err(e) => {
             debug!("{}", audit);
@@ -459,7 +460,7 @@ pub fn create_server_core(config: Configuration) {
 
     let mut audit = AuditScope::new("setup_qs_idms");
     // Start the IDM server.
-    let (qs, idms) = match setup_qs_idms(&mut audit, be) {
+    let (qs, idms) = match setup_qs_idms(&mut audit, be, config.server_id.clone()) {
         Ok(t) => t,
         Err(e) => {
             debug!("{}", audit);

--- a/rsidmd/src/lib/core.rs
+++ b/rsidmd/src/lib/core.rs
@@ -21,6 +21,7 @@ use crate::idm::server::IdmServer;
 use crate::interval::IntervalActor;
 use crate::schema::Schema;
 use crate::server::QueryServer;
+use crate::utils::SID;
 use rsidm_proto::v1::OperationError;
 use rsidm_proto::v1::{
     AuthRequest, AuthState, CreateRequest, DeleteRequest, ModifyRequest, SearchRequest,
@@ -274,7 +275,7 @@ fn setup_backend(config: &Configuration) -> Result<Backend, OperationError> {
 fn setup_qs_idms(
     audit: &mut AuditScope,
     be: Backend,
-    sid: [u8; 6],
+    sid: SID,
 ) -> Result<(QueryServer, IdmServer), OperationError> {
     // Create "just enough" schema for us to be able to load from
     // disk ... Schema loading is one time where we validate the

--- a/rsidmd/src/lib/idm/macros.rs
+++ b/rsidmd/src/lib/idm/macros.rs
@@ -35,7 +35,7 @@ macro_rules! run_idm_test {
             .initialise_helper(&mut audit)
             .expect("init failed");
 
-        let test_idm_server = IdmServer::new(test_server.clone(), [0; 6]);
+        let test_idm_server = IdmServer::new(test_server.clone(), [0; 4]);
 
         $test_fn(&test_server, &test_idm_server, &mut audit);
         // Any needed teardown?

--- a/rsidmd/src/lib/idm/macros.rs
+++ b/rsidmd/src/lib/idm/macros.rs
@@ -35,7 +35,7 @@ macro_rules! run_idm_test {
             .initialise_helper(&mut audit)
             .expect("init failed");
 
-        let test_idm_server = IdmServer::new(test_server.clone());
+        let test_idm_server = IdmServer::new(test_server.clone(), [0; 6]);
 
         $test_fn(&test_server, &test_idm_server, &mut audit);
         // Any needed teardown?

--- a/rsidmd/src/lib/idm/server.rs
+++ b/rsidmd/src/lib/idm/server.rs
@@ -12,6 +12,7 @@ use rsidm_proto::v1::OperationError;
 use concread::cowcell::{CowCell, CowCellWriteTxn};
 use std::collections::BTreeMap;
 use uuid::Uuid;
+use uuid::v1::Context;
 
 pub struct IdmServer {
     // There is a good reason to keep this single thread - it
@@ -24,6 +25,10 @@ pub struct IdmServer {
     sessions: CowCell<BTreeMap<Uuid, AuthSession>>,
     // Need a reference to the query server.
     qs: QueryServer,
+    // thread/server id
+    sid: [u8; 6],
+    // context
+    uctx: Context,
 }
 
 pub struct IdmServerWriteTransaction<'a> {
@@ -50,10 +55,12 @@ pub struct IdmServerProxyWriteTransaction<'a> {
 
 impl IdmServer {
     // TODO #59: Make number of authsessions configurable!!!
-    pub fn new(qs: QueryServer) -> IdmServer {
+    pub fn new(qs: QueryServer, sid: [u8; 6]) -> IdmServer {
         IdmServer {
             sessions: CowCell::new(BTreeMap::new()),
             qs: qs,
+            sid: sid,
+            uctx: Context::new(1),
         }
     }
 

--- a/rsidmd/src/lib/lib.rs
+++ b/rsidmd/src/lib/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings)]
+// #![deny(warnings)]
 #![warn(unused_extern_crates)]
 
 #[macro_use]
@@ -12,6 +12,7 @@ extern crate lazy_static;
 // This has to be before be so the import order works
 #[macro_use]
 mod macros;
+mod utils;
 #[macro_use]
 mod async_log;
 #[macro_use]

--- a/rsidmd/src/lib/lib.rs
+++ b/rsidmd/src/lib/lib.rs
@@ -1,4 +1,4 @@
-// #![deny(warnings)]
+#![deny(warnings)]
 #![warn(unused_extern_crates)]
 
 #[macro_use]

--- a/rsidmd/src/lib/utils.rs
+++ b/rsidmd/src/lib/utils.rs
@@ -1,5 +1,5 @@
+use std::time::Duration;
 use uuid::{Builder, Uuid};
-use std::time::{Duration};
 
 pub type SID = [u8; 4];
 
@@ -17,21 +17,23 @@ pub fn uuid_from_duration(d: Duration, sid: &SID) -> Uuid {
     uuid_from_u64_u32(d.as_secs(), d.subsec_nanos(), sid)
 }
 
-
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
     use crate::utils::uuid_from_duration;
+    use std::time::Duration;
 
     #[test]
     fn test_utils_uuid_from_duration() {
         let u1 = uuid_from_duration(Duration::from_secs(1), &[0xff; 4]);
-        assert_eq!("00000000-0000-0001-0000-0000ffffffff", u1.to_hyphenated().to_string());
+        assert_eq!(
+            "00000000-0000-0001-0000-0000ffffffff",
+            u1.to_hyphenated().to_string()
+        );
 
         let u2 = uuid_from_duration(Duration::from_secs(1000), &[0xff; 4]);
-        assert_eq!("00000000-0000-03e8-0000-0000ffffffff", u2.to_hyphenated().to_string());
+        assert_eq!(
+            "00000000-0000-03e8-0000-0000ffffffff",
+            u2.to_hyphenated().to_string()
+        );
     }
 }
-
-
-

--- a/rsidmd/src/lib/utils.rs
+++ b/rsidmd/src/lib/utils.rs
@@ -1,7 +1,9 @@
 use uuid::{Builder, Uuid};
 use std::time::{Duration};
 
-fn uuid_from_u64_u32(a: u64, b: u32, sid: &[u8; 4]) -> Uuid {
+pub type SID = [u8; 4];
+
+fn uuid_from_u64_u32(a: u64, b: u32, sid: &SID) -> Uuid {
     let mut v: Vec<u8> = Vec::with_capacity(16);
     v.extend_from_slice(&a.to_be_bytes());
     v.extend_from_slice(&b.to_be_bytes());
@@ -11,7 +13,7 @@ fn uuid_from_u64_u32(a: u64, b: u32, sid: &[u8; 4]) -> Uuid {
 }
 
 // SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
-fn uuid_from_duration(d: Duration, sid: &[u8; 4]) -> Uuid {
+pub fn uuid_from_duration(d: Duration, sid: &SID) -> Uuid {
     uuid_from_u64_u32(d.as_secs(), d.subsec_nanos(), sid)
 }
 

--- a/rsidmd/src/lib/utils.rs
+++ b/rsidmd/src/lib/utils.rs
@@ -1,0 +1,35 @@
+use uuid::{Builder, Uuid};
+use std::time::{Duration};
+
+fn uuid_from_u64_u32(a: u64, b: u32, sid: &[u8; 4]) -> Uuid {
+    let mut v: Vec<u8> = Vec::with_capacity(16);
+    v.extend_from_slice(&a.to_be_bytes());
+    v.extend_from_slice(&b.to_be_bytes());
+    v.extend_from_slice(sid);
+
+    Builder::from_slice(v.as_slice()).unwrap().build()
+}
+
+// SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
+fn uuid_from_duration(d: Duration, sid: &[u8; 4]) -> Uuid {
+    uuid_from_u64_u32(d.as_secs(), d.subsec_nanos(), sid)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+    use crate::utils::uuid_from_duration;
+
+    #[test]
+    fn test_utils_uuid_from_duration() {
+        let u1 = uuid_from_duration(Duration::from_secs(1), &[0xff; 4]);
+        assert_eq!("00000000-0000-0001-0000-0000ffffffff", u1.to_hyphenated().to_string());
+
+        let u2 = uuid_from_duration(Duration::from_secs(1000), &[0xff; 4]);
+        assert_eq!("00000000-0000-03e8-0000-0000ffffffff", u2.to_hyphenated().to_string());
+    }
+}
+
+
+


### PR DESCRIPTION
Implements #60 authsession garbage collection. If we assume that an authsession is around 1024 bytes (this assumes a 16 char name + groups + claims) then this means that in 1Gb of ram we can store about 1 million in progress auth attempts. Obviously, we don't want infinite memory growth, but we can't use an LRU cache due to the future desire to use concurrent trees. So instead we prune the tree based on a timeout when we start and auth operation. Auth session id's are generated from a timestamp similar to how we'll generate replication csn's. We can then apply a diff that will split all items lower than the csn/sid and remove them from future consideration.

We set the default timeout to 5 minutes. This means that assuming 10,000 auths per second, we would require 3GB of ram to process these sessions before they are expired. We expect any deployment with such large loadings can affort 3Gb of ram :) 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ - ] design document included (if relevant)
