### PR TITLE
65 cli options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,39 @@ See [CODE_OF_CONDUCT.md]
 
 ## Quick start
 
-Details to come ...
+Today the server is still in a state of heavy development, and hasn't been packaged or setup for
+production usage.
+
+However, we are able to run test or demo servers that are suitable for previews and testing.
+
+After getting the code, you will need a rust environment. Please investigate rustup for your platform
+to establish this.
+
+Once you have the source code, you need certificates to use with the server. I recommend using
+let's encrypt, but if this is not possible, please use our insecure cert tool:
+
+    mkdir insecure
+    cd insecure
+    ../insecure_generate_tls.sh
+
+You can now build and run the server with:
+
+    cd rsidmd
+    cargo run -- server -D /tmp/kanidm.db -C ../insecure/ca.pem -c ../insecure/cert.pem -k ../insecure/key.pem
+
+In a new terminal, you can now build and run the client tools with:
+
+    cd rsidm_tools
+    cargo run -- --help
+    cargo run -- whoami -H https://localhost:8080 -D anonymous -C ../insecure/ca.pem
+
+## Development and Testing
+
+There are tests of various components through the various components of the project. When developing
+it't best if you test in the component you are working on, followed by the full server tests.
+
+There are *no* prerequisites to running these tests or special configurations. cargo test should
+just work!
 
 ## Implemented/Planned features
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ let's encrypt, but if this is not possible, please use our insecure cert tool:
 You can now build and run the server with:
 
     cd rsidmd
-    cargo run -- server -D /tmp/kanidm.db -C ../insecure/ca.pem -c ../insecure/cert.pem -k ../insecure/key.pem
+    cargo run -- server -D /tmp/kanidm.db -C ../insecure/ca.pem -c ../insecure/cert.pem -k ../insecure/key.pem --domain localhost --bindaddr 127.0.0.1:8080
 
 In a new terminal, you can now build and run the client tools with:
 

--- a/insecure_generate_tls.sh
+++ b/insecure_generate_tls.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+cat > ./altnames.cnf << DEVEOF
+[req]
+req_extensions = v3_req
+nsComment = "Certificate"
+distinguished_name  = req_distinguished_name
+
+[ req_distinguished_name ]
+
+countryName                     = Country Name (2 letter code)
+countryName_default             = AU
+countryName_min                 = 2
+countryName_max                 = 2
+
+stateOrProvinceName             = State or Province Name (full name)
+stateOrProvinceName_default     = Queensland
+
+localityName                    = Locality Name (eg, city)
+localityName_default            = Brisbane
+
+0.organizationName              = Organization Name (eg, company)
+0.organizationName_default      = INSECURE EXAMPLE
+
+organizationalUnitName          = Organizational Unit Name (eg, section)
+organizationalUnitName_default =  KaniDM
+
+commonName                      = Common Name (eg, your name or your server\'s hostname)
+commonName_max                  = 64
+commonName_default              = localhost
+
+[ v3_req ]
+
+# Extensions to add to a certificate request
+
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = 127.0.0.1
+
+DEVEOF
+
+# Make the ca
+openssl req -x509 -new -newkey rsa:2048 -keyout cakey.pem -out ca.pem -days 31 -subj "/C=AU/ST=Queensland/L=Brisbane/O=INSECURE/CN=insecure.ca.localhost" -nodes
+openssl genrsa -out key.pem 2048
+openssl req -key key.pem -out cert.csr -days 31 -config altnames.cnf -new
+openssl x509 -req -days 31 -in cert.csr -CA ca.pem -CAkey cakey.pem -CAcreateserial -out cert.pem
+
+echo use ca.pem, cert.pem, and key.pem
+

--- a/rsidm_client/src/lib.rs
+++ b/rsidm_client/src/lib.rs
@@ -40,13 +40,10 @@ impl RsidmClient {
             reqwest::Certificate::from_pem(&buf).expect("Failed to parse ca")
         });
 
-        let client_builder = reqwest::Client::builder()
-            .cookie_store(true);
+        let client_builder = reqwest::Client::builder().cookie_store(true);
 
         let client_builder = match ca {
-            Some(cert) => {
-                client_builder.add_root_certificate(cert)
-            }
+            Some(cert) => client_builder.add_root_certificate(cert),
             None => client_builder,
         };
 

--- a/rsidm_client/tests/proto_v1_test.rs
+++ b/rsidm_client/tests/proto_v1_test.rs
@@ -71,7 +71,7 @@ fn run_test(test_fn: fn(RsidmClient) -> ()) {
 
     // Setup the client, and the address we selected.
     let addr = format!("http://127.0.0.1:{}", port);
-    let rsclient = RsidmClient::new(addr.as_str());
+    let rsclient = RsidmClient::new(addr.as_str(), None);
 
     test_fn(rsclient);
 

--- a/rsidm_tools/src/main.rs
+++ b/rsidm_tools/src/main.rs
@@ -1,5 +1,6 @@
 extern crate structopt;
 use rsidm_client::RsidmClient;
+use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -8,11 +9,14 @@ struct CommonOpt {
     addr: String,
     #[structopt(short = "D", long = "name")]
     username: String,
+    #[structopt(parse(from_os_str), short = "C", long = "ca")]
+    ca_path: Option<PathBuf>,
 }
 
 impl CommonOpt {
     fn to_client(&self) -> RsidmClient {
-        RsidmClient::new(self.addr.as_str())
+        let ca_path: Option<&str> = self.ca_path.as_ref().map(|p| p.to_str().unwrap());
+        RsidmClient::new(self.addr.as_str(), ca_path)
     }
 }
 

--- a/rsidmd/Cargo.toml
+++ b/rsidmd/Cargo.toml
@@ -20,7 +20,8 @@ path = "src/server/main.rs"
 rsidm_proto = { path = "../rsidm_proto" }
 
 actix = "0.7"
-actix-web = "0.7"
+actix-web = { version = "0.7", features = ["ssl"] }
+
 bytes = "0.4"
 log = "0.4"
 env_logger = "0.6"
@@ -52,4 +53,5 @@ concread = "0.1"
 openssl = "0.10"
 
 rpassword = "0.4"
+num_cpus = "1.10"
 

--- a/rsidmd/src/lib/config.rs
+++ b/rsidmd/src/lib/config.rs
@@ -1,4 +1,3 @@
-use crate::utils::SID;
 use rand::prelude::*;
 use std::path::PathBuf;
 use std::fmt;
@@ -27,7 +26,6 @@ pub struct Configuration {
     pub secure_cookies: bool,
     pub tls_config: Option<TlsConfiguration>,
     pub cookie_key: [u8; 32],
-    pub server_id: SID,
     pub integration_test_config: Option<Box<IntegrationTestConfig>>,
 }
 
@@ -40,8 +38,7 @@ impl fmt::Display for Configuration {
             .and_then(|_| write!(f, "max request size: {}b, ", self.maximum_request))
             .and_then(|_| write!(f, "secure cookies: {}, ", self.secure_cookies))
             .and_then(|_| write!(f, "with TLS: {}, ", self.tls_config.is_some()))
-            .and_then(|_| write!(f, "server_id: {:?}, ", self.server_id))
-        .and_then(|_| write!(f, "integration mode: {}", self.integration_test_config.is_some()))
+            .and_then(|_| write!(f, "integration mode: {}", self.integration_test_config.is_some()))
     }
 }
 
@@ -59,17 +56,10 @@ impl Configuration {
             secure_cookies: if cfg!(test) { false } else { true },
             tls_config: None,
             cookie_key: [0; 32],
-            server_id: [0; 4],
             integration_test_config: None,
         };
         let mut rng = StdRng::from_entropy();
-
-        // Does the sid file exist?
-        // yes? Read from it
-        // no? write it after we gen the sid.
-
         rng.fill(&mut c.cookie_key);
-        rng.fill(&mut c.server_id);
         c
     }
 

--- a/rsidmd/src/lib/config.rs
+++ b/rsidmd/src/lib/config.rs
@@ -1,10 +1,19 @@
 use crate::utils::SID;
 use rand::prelude::*;
 use std::path::PathBuf;
+use std::fmt;
+use num_cpus;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct IntegrationTestConfig {
     pub admin_password: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TlsConfiguration {
+    pub ca: String,
+    pub cert: String,
+    pub key: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -16,9 +25,24 @@ pub struct Configuration {
     pub db_path: String,
     pub maximum_request: usize,
     pub secure_cookies: bool,
+    pub tls_config: Option<TlsConfiguration>,
     pub cookie_key: [u8; 32],
     pub server_id: SID,
     pub integration_test_config: Option<Box<IntegrationTestConfig>>,
+}
+
+impl fmt::Display for Configuration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "address: {}, ", self.address)
+            .and_then(|_| write!(f, "domain: {}, ", self.domain))
+            .and_then(|_| write!(f, "thread count: {}, ", self.threads))
+            .and_then(|_| write!(f, "dbpath: {}, ", self.db_path))
+            .and_then(|_| write!(f, "max request size: {}b, ", self.maximum_request))
+            .and_then(|_| write!(f, "secure cookies: {}, ", self.secure_cookies))
+            .and_then(|_| write!(f, "with TLS: {}, ", self.tls_config.is_some()))
+            .and_then(|_| write!(f, "server_id: {:?}, ", self.server_id))
+        .and_then(|_| write!(f, "integration mode: {}", self.integration_test_config.is_some()))
+    }
 }
 
 impl Configuration {
@@ -26,19 +50,24 @@ impl Configuration {
         let mut c = Configuration {
             address: String::from("127.0.0.1:8080"),
             domain: String::from("localhost"),
-            threads: 8,
+            threads: num_cpus::get(),
             db_path: String::from(""),
             maximum_request: 262144, // 256k
             // log type
             // log path
             // TODO #63: default true in prd
-            // secure_cookies: if cfg!(test) { false } else { true },
-            secure_cookies: false,
+            secure_cookies: if cfg!(test) { false } else { true },
+            tls_config: None,
             cookie_key: [0; 32],
             server_id: [0; 4],
             integration_test_config: None,
         };
         let mut rng = StdRng::from_entropy();
+
+        // Does the sid file exist?
+        // yes? Read from it
+        // no? write it after we gen the sid.
+
         rng.fill(&mut c.cookie_key);
         rng.fill(&mut c.server_id);
         c
@@ -53,4 +82,46 @@ impl Configuration {
             }
         }
     }
+
+    pub fn update_tls(&mut self, ca: &Option<PathBuf>, cert: &Option<PathBuf>, key: &Option<PathBuf>) {
+        match (ca, cert, key) {
+            (None, None, None) => {}
+            (Some(cap), Some(certp), Some(keyp)) => {
+                let cas = match cap.to_str() {
+                    Some(cav) => cav.to_string(),
+                    None => {
+                        error!("Invalid CA path");
+                        std::process::exit(1);
+                    }
+                };
+                let certs = match certp.to_str() {
+                    Some(certv) => certv.to_string(),
+                    None => {
+                        error!("Invalid Cert path");
+                        std::process::exit(1);
+                    }
+                };
+                let keys = match keyp.to_str() {
+                    Some(keyv) => keyv.to_string(),
+                    None => {
+                        error!("Invalid Key path");
+                        std::process::exit(1);
+                    }
+                };
+                self.tls_config = Some(
+                    TlsConfiguration {
+                        ca: cas,
+                        cert: certs,
+                        key: keys,
+                    }
+                )
+            }
+            _ => {
+                error!("Invalid TLS configuration - must provide ca, cert and key!");
+                std::process::exit(1);
+            }
+        }
+    }
+
+
 }

--- a/rsidmd/src/lib/core.rs
+++ b/rsidmd/src/lib/core.rs
@@ -19,12 +19,12 @@ use crate::actors::v1::{
 use crate::async_log;
 use crate::audit::AuditScope;
 use crate::be::{Backend, BackendTransaction};
+use crate::crypto::setup_tls;
 use crate::idm::server::IdmServer;
 use crate::interval::IntervalActor;
 use crate::schema::Schema;
 use crate::server::QueryServer;
 use crate::utils::SID;
-use crate::crypto::setup_tls;
 use rsidm_proto::v1::OperationError;
 use rsidm_proto::v1::{
     AuthRequest, AuthState, CreateRequest, DeleteRequest, ModifyRequest, SearchRequest,
@@ -606,9 +606,7 @@ pub fn create_server_core(config: Configuration) {
     });
 
     let tls_aws_builder = match opt_tls_params {
-        Some(tls_params) => {
-            aws_builder.bind_ssl(config.address, tls_params)
-        }
+        Some(tls_params) => aws_builder.bind_ssl(config.address, tls_params),
         None => {
             warn!("Starting WITHOUT TLS parameters. This may cause authentication to fail!");
             aws_builder.bind(config.address)

--- a/rsidmd/src/lib/crypto.rs
+++ b/rsidmd/src/lib/crypto.rs
@@ -1,22 +1,17 @@
-
 use crate::config::Configuration;
-use openssl::ssl::{SslAcceptor, SslAcceptorBuilder, SslMethod, SslFiletype};
 use openssl::error::ErrorStack;
+use openssl::ssl::{SslAcceptor, SslAcceptorBuilder, SslFiletype, SslMethod};
 
 pub fn setup_tls(config: &Configuration) -> Result<Option<SslAcceptorBuilder>, ErrorStack> {
     match &config.tls_config {
         Some(tls_config) => {
-            let mut ssl_builder =
-                SslAcceptor::mozilla_modern(SslMethod::tls())?;
+            let mut ssl_builder = SslAcceptor::mozilla_modern(SslMethod::tls())?;
             ssl_builder.set_ca_file(&tls_config.ca)?;
-            ssl_builder
-                .set_private_key_file(&tls_config.key, SslFiletype::PEM)?;
-            ssl_builder
-                .set_certificate_file(&tls_config.cert, SslFiletype::PEM)?;
+            ssl_builder.set_private_key_file(&tls_config.key, SslFiletype::PEM)?;
+            ssl_builder.set_certificate_file(&tls_config.cert, SslFiletype::PEM)?;
             ssl_builder.check_private_key()?;
             Ok(Some(ssl_builder))
         }
-        None => Ok(None)
+        None => Ok(None),
     }
 }
-

--- a/rsidmd/src/lib/crypto.rs
+++ b/rsidmd/src/lib/crypto.rs
@@ -1,0 +1,22 @@
+
+use crate::config::Configuration;
+use openssl::ssl::{SslAcceptor, SslAcceptorBuilder, SslMethod, SslFiletype};
+use openssl::error::ErrorStack;
+
+pub fn setup_tls(config: &Configuration) -> Result<Option<SslAcceptorBuilder>, ErrorStack> {
+    match &config.tls_config {
+        Some(tls_config) => {
+            let mut ssl_builder =
+                SslAcceptor::mozilla_modern(SslMethod::tls())?;
+            ssl_builder.set_ca_file(&tls_config.ca)?;
+            ssl_builder
+                .set_private_key_file(&tls_config.key, SslFiletype::PEM)?;
+            ssl_builder
+                .set_certificate_file(&tls_config.cert, SslFiletype::PEM)?;
+            ssl_builder.check_private_key()?;
+            Ok(Some(ssl_builder))
+        }
+        None => Ok(None)
+    }
+}
+

--- a/rsidmd/src/lib/lib.rs
+++ b/rsidmd/src/lib/lib.rs
@@ -13,6 +13,7 @@ extern crate lazy_static;
 #[macro_use]
 mod macros;
 mod utils;
+mod crypto;
 #[macro_use]
 mod async_log;
 #[macro_use]

--- a/rsidmd/src/lib/lib.rs
+++ b/rsidmd/src/lib/lib.rs
@@ -12,8 +12,8 @@ extern crate lazy_static;
 // This has to be before be so the import order works
 #[macro_use]
 mod macros;
-mod utils;
 mod crypto;
+mod utils;
 #[macro_use]
 mod async_log;
 #[macro_use]

--- a/rsidmd/src/server/main.rs
+++ b/rsidmd/src/server/main.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-struct ServerOpt {
+struct CommonOpt {
     #[structopt(short = "d", long = "debug")]
     debug: bool,
     #[structopt(parse(from_os_str), short = "D", long = "db_path")]
@@ -27,11 +27,23 @@ struct ServerOpt {
 }
 
 #[derive(Debug, StructOpt)]
+struct ServerOpt {
+    #[structopt(parse(from_os_str), short = "C", long = "ca")]
+    ca_path: Option<PathBuf>,
+    #[structopt(parse(from_os_str), short = "c", long = "cert")]
+    cert_path: Option<PathBuf>,
+    #[structopt(parse(from_os_str), short = "k", long = "key")]
+    key_path: Option<PathBuf>,
+    #[structopt(flatten)]
+    commonopts: CommonOpt,
+}
+
+#[derive(Debug, StructOpt)]
 struct BackupOpt {
     #[structopt(parse(from_os_str))]
     path: PathBuf,
     #[structopt(flatten)]
-    serveropts: ServerOpt,
+    commonopts: CommonOpt,
 }
 
 #[derive(Debug, StructOpt)]
@@ -39,7 +51,7 @@ struct RestoreOpt {
     #[structopt(parse(from_os_str))]
     path: PathBuf,
     #[structopt(flatten)]
-    serveropts: ServerOpt,
+    commonopts: CommonOpt,
 }
 
 #[derive(Debug, StructOpt)]
@@ -47,7 +59,7 @@ struct RecoverAccountOpt {
     #[structopt(short)]
     name: String,
     #[structopt(flatten)]
-    serveropts: ServerOpt,
+    commonopts: CommonOpt,
 }
 
 #[derive(Debug, StructOpt)]
@@ -59,7 +71,7 @@ enum Opt {
     #[structopt(name = "restore")]
     Restore(RestoreOpt),
     #[structopt(name = "verify")]
-    Verify(ServerOpt),
+    Verify(CommonOpt),
     #[structopt(name = "recover_account")]
     RecoverAccount(RecoverAccountOpt),
 }
@@ -67,10 +79,11 @@ enum Opt {
 impl Opt {
     fn debug(&self) -> bool {
         match self {
-            Opt::Server(sopt) | Opt::Verify(sopt) => sopt.debug,
-            Opt::Backup(bopt) => bopt.serveropts.debug,
-            Opt::Restore(ropt) => ropt.serveropts.debug,
-            Opt::RecoverAccount(ropt) => ropt.serveropts.debug,
+            Opt::Server(sopt) => sopt.commonopts.debug,
+            Opt::Verify(sopt) => sopt.debug,
+            Opt::Backup(bopt) => bopt.commonopts.debug,
+            Opt::Restore(ropt) => ropt.commonopts.debug,
+            Opt::RecoverAccount(ropt) => ropt.commonopts.debug,
         }
     }
 }
@@ -96,7 +109,8 @@ fn main() {
         Opt::Server(sopt) => {
             info!("Running in server mode ...");
 
-            config.update_db_path(&sopt.db_path);
+            config.update_db_path(&sopt.commonopts.db_path);
+            config.update_tls(&sopt.ca_path, &sopt.cert_path, &sopt.key_path);
 
             let sys = actix::System::new("rsidm-server");
             create_server_core(config);
@@ -105,7 +119,7 @@ fn main() {
         Opt::Backup(bopt) => {
             info!("Running in backup mode ...");
 
-            config.update_db_path(&bopt.serveropts.db_path);
+            config.update_db_path(&bopt.commonopts.db_path);
 
             let p = match bopt.path.to_str() {
                 Some(p) => p,
@@ -119,7 +133,7 @@ fn main() {
         Opt::Restore(ropt) => {
             info!("Running in restore mode ...");
 
-            config.update_db_path(&ropt.serveropts.db_path);
+            config.update_db_path(&ropt.commonopts.db_path);
 
             let p = match ropt.path.to_str() {
                 Some(p) => p,
@@ -140,7 +154,7 @@ fn main() {
             info!("Running account recovery ...");
 
             let password = rpassword::prompt_password_stderr("new password: ").unwrap();
-            config.update_db_path(&raopt.serveropts.db_path);
+            config.update_db_path(&raopt.commonopts.db_path);
 
             recover_account_core(config, raopt.name, password);
         }

--- a/rsidmd/src/server/main.rs
+++ b/rsidmd/src/server/main.rs
@@ -11,8 +11,8 @@ extern crate log;
 
 use rsidm::config::Configuration;
 use rsidm::core::{
-    backup_server_core, create_server_core, recover_account_core, restore_server_core,
-    verify_server_core, reset_sid_core
+    backup_server_core, create_server_core, recover_account_core, reset_sid_core,
+    restore_server_core, verify_server_core,
 };
 
 use std::path::PathBuf;
@@ -34,6 +34,10 @@ struct ServerOpt {
     cert_path: Option<PathBuf>,
     #[structopt(parse(from_os_str), short = "k", long = "key")]
     key_path: Option<PathBuf>,
+    #[structopt(short = "r", long = "domain")]
+    domain: String,
+    #[structopt(short = "b", long = "bindaddr")]
+    bind: Option<String>,
     #[structopt(flatten)]
     commonopts: CommonOpt,
 }
@@ -113,6 +117,8 @@ fn main() {
 
             config.update_db_path(&sopt.commonopts.db_path);
             config.update_tls(&sopt.ca_path, &sopt.cert_path, &sopt.key_path);
+            config.update_bind(&sopt.bind);
+            config.domain = sopt.domain.clone();
 
             let sys = actix::System::new("rsidm-server");
             create_server_core(config);

--- a/rsidmd/src/server/main.rs
+++ b/rsidmd/src/server/main.rs
@@ -12,7 +12,7 @@ extern crate log;
 use rsidm::config::Configuration;
 use rsidm::core::{
     backup_server_core, create_server_core, recover_account_core, restore_server_core,
-    verify_server_core,
+    verify_server_core, reset_sid_core
 };
 
 use std::path::PathBuf;
@@ -74,13 +74,15 @@ enum Opt {
     Verify(CommonOpt),
     #[structopt(name = "recover_account")]
     RecoverAccount(RecoverAccountOpt),
+    #[structopt(name = "reset_server_id")]
+    ResetServerId(CommonOpt),
 }
 
 impl Opt {
     fn debug(&self) -> bool {
         match self {
             Opt::Server(sopt) => sopt.commonopts.debug,
-            Opt::Verify(sopt) => sopt.debug,
+            Opt::Verify(sopt) | Opt::ResetServerId(sopt) => sopt.debug,
             Opt::Backup(bopt) => bopt.commonopts.debug,
             Opt::Restore(ropt) => ropt.commonopts.debug,
             Opt::RecoverAccount(ropt) => ropt.commonopts.debug,
@@ -157,6 +159,12 @@ fn main() {
             config.update_db_path(&raopt.commonopts.db_path);
 
             recover_account_core(config, raopt.name, password);
+        }
+        Opt::ResetServerId(vopt) => {
+            info!("Resetting server id. THIS MAY BREAK REPLICATION");
+
+            config.update_db_path(&vopt.db_path);
+            reset_sid_core(config);
         }
     }
 }


### PR DESCRIPTION
Implements #65 command line options. This updates the command line to support sid regeneration, domain and address binding, tls support to the server, and clarifies a few other details. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ - ] design document included (if relevant)
