### PR TITLE
Implement resolving references to names on entry to proto entry convert.

### DIFF
--- a/rsidm_tools/Cargo.toml
+++ b/rsidm_tools/Cargo.toml
@@ -12,4 +12,6 @@ path = "src/main.rs"
 rsidm_client = { path = "../rsidm_client" }
 rpassword = "0.4"
 structopt = { version = "0.2", default-features = false }
+log = "0.4"
+env_logger = "0.6"
 

--- a/rsidmd/src/lib/actors/v1.rs
+++ b/rsidmd/src/lib/actors/v1.rs
@@ -185,9 +185,7 @@ impl Handler<SearchMessage> for QueryServerV1 {
 
             match qs_read.search_ext(&mut audit, &srch) {
                 Ok(entries) => {
-                    let sr = SearchResult::new(entries);
-                    // Now convert to a response, and return
-                    Ok(sr.response())
+                    SearchResult::new(&mut audit, &qs_read, entries).map(|ok_sr| ok_sr.response())
                 }
                 Err(e) => Err(e),
             }
@@ -365,8 +363,8 @@ impl Handler<WhoamiMessage> for QueryServerV1 {
                         1 => {
                             let e = entries.pop().expect("Entry length mismatch!!!");
                             // Now convert to a response, and return
-                            let wr = WhoamiResult::new(e, uat);
-                            Ok(wr.response())
+                            WhoamiResult::new(&mut audit, &qs_read, e, uat)
+                                .map(|ok_wr| ok_wr.response())
                         }
                         // Somehow we matched multiple, which should be impossible.
                         _ => Err(OperationError::InvalidState),

--- a/rsidmd/src/lib/constants.rs
+++ b/rsidmd/src/lib/constants.rs
@@ -154,7 +154,7 @@ pub static JSON_IDM_ADMINS_ACP_MANAGE_V1: &'static str = r#"{
         "acp_targetscope": [
             "{\"Pres\":\"class\"}"
         ],
-        "acp_search_attr": ["name", "class", "uuid", "classname", "attributename"],
+        "acp_search_attr": ["name", "class", "uuid", "classname", "attributename", "memberof"],
         "acp_modify_class": ["person"],
         "acp_modify_removedattr": ["class", "displayname", "name", "description"],
         "acp_modify_presentattr": ["class", "displayname", "name", "description"],

--- a/rsidmd/src/lib/value.rs
+++ b/rsidmd/src/lib/value.rs
@@ -768,28 +768,6 @@ impl Value {
         }
     }
 
-    /// Convert to a proto/public value that can be read and consumed.
-    pub(crate) fn to_proto_string_clone(&self) -> String {
-        match &self.pv {
-            PartialValue::Utf8(s) => s.clone(),
-            PartialValue::Iutf8(s) => s.clone(),
-            PartialValue::Uuid(u) => u.to_hyphenated_ref().to_string(),
-            PartialValue::Bool(b) => b.to_string(),
-            PartialValue::Syntax(syn) => syn.to_string(),
-            PartialValue::Index(it) => it.to_string(),
-            // TODO: These should be uuid_to_name in server
-            PartialValue::Refer(u) => u.to_hyphenated_ref().to_string(),
-            PartialValue::JsonFilt(s) => {
-                serde_json::to_string(s).expect("A json filter value was corrupted during run-time")
-            }
-            PartialValue::Cred(tag) => {
-                // You can't actually read the credential values because we only display the
-                // tag to the proto side. The credentials private data is stored seperately.
-                tag.to_string()
-            }
-        }
-    }
-
     pub fn to_str(&self) -> Option<&str> {
         match &self.pv {
             PartialValue::Utf8(s) => Some(s.as_str()),
@@ -851,6 +829,28 @@ impl Value {
     pub fn to_partialvalue(&self) -> PartialValue {
         // Match on self to become a partialvalue.
         self.pv.clone()
+    }
+
+    pub(crate) fn to_proto_string_clone(&self) -> String {
+        match &self.pv {
+            PartialValue::Utf8(s) => s.clone(),
+            PartialValue::Iutf8(s) => s.clone(),
+            PartialValue::Uuid(u) => u.to_hyphenated_ref().to_string(),
+            PartialValue::Bool(b) => b.to_string(),
+            PartialValue::Syntax(syn) => syn.to_string(),
+            PartialValue::Index(it) => it.to_string(),
+            // In resolve value, we bypass this, but we keep it here for complete
+            // impl sake.
+            PartialValue::Refer(u) => u.to_hyphenated_ref().to_string(),
+            PartialValue::JsonFilt(s) => {
+                serde_json::to_string(s).expect("A json filter value was corrupted during run-time")
+            }
+            PartialValue::Cred(tag) => {
+                // You can't actually read the credential values because we only display the
+                // tag to the proto side. The credentials private data is stored seperately.
+                tag.to_string()
+            }
+        }
     }
 
     pub fn validate(&self) -> bool {


### PR DESCRIPTION
Implements #83 . This now resolves references to names if possible, otherwise we just sent the uuid string instead. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ - ] design document included (if relevant)
