### PR TITLE
87 default idm entries

### DIFF
--- a/designs/default_idm_layout.rst
+++ b/designs/default_idm_layout.rst
@@ -1,0 +1,159 @@
+
+Default IDM Layout
+------------------
+
+It's important we have a good default IDM entry layout, as this will serve as examples and
+guidance for many users. We also need to consider that the defaults may be ignored also, but
+many users will consume them by default.
+
+Additionally, we also need to think carefully about the roles and interactions with the
+default entries, and how people will deploy and interact with software like this. This document
+is to discuss the roles and their requirements, rather than the absolute details of the implementation.
+
+Privileged Groups
+-----------------
+
+Due to the RBAC design of the system, it's important to consider that some groups will have a large
+amount of ability in the server, and should be managed carefully. It is because of this that
+groups with a high amount of power will also be a member of the "high access" group. This means
+we can target access controls over the high access group, but we can also quickly and easily find
+accounts that are members. It may even be possible to audit on addition of "high access" as memberof
+to any account.
+
+Initialisation and System Setup
+-------------------------------
+
+These are initialised with the normal migrations framework. We must consider that
+migrations could remove some admins changes, so we must choose the migration
+strategy carefully. There is benefit to acp improvement on upgrade, but also
+some deployments may not wish for this.
+
+Security Notes
+--------------
+
+In the design of this, I did consider the usage of targetreceiver rules in these defaults
+that use the AndNot could create a scenario where someone copies or creates their own
+access controls and forgets to include the "high access" exclusion. I think that generally
+in the cases where someone is creating their own access controls, they will use stricter targeting
+such as directly listing groups, rather than broad accesses like this. I also think that many
+people will use these as examples, so it will be visible to copy the require and-not's if needed.
+
+Roles
+-----
+
+This is a list of roles/groups and some loose requirements, but also thoughts and justification of
+the design and setup.
+
+Users
+=====
+
+Users is the class of all accounts that can authenticate. It's important that users by default have
+full self-view rights, but also that they have a set of limited self-write rights. An example of
+a self write we disallow is changing unix attributes.
+
+* Read to all self attributes (within security constraints).
+* Write to a limited set of self attributes, such as name, displayname, legalname, ssh-keys, credentials etc.
+
+Account Managers
+================
+
+Account managers are people who are tasked to support and aid with technical interactions of a user
+with this system. Classically this would be a service desk who would require this role. Importantly
+compared to some other roles, this will need to potentially be able to reset credentials for an
+account.
+
+As a result, this is high access. This role importantly should NOT be able to lock or alter
+credentials of high access granted accounts. That must be performed by a higher privilege.
+
+* read and write to accounts, including credentials but NOT private data (see people manager)
+* ability to lock and unlock accounts, excluding high access members.
+
+
+Group Manager
+=============
+
+This is a role who is able to manage and create groups on the system. Note this does not include
+high access groups. This is intended to be for support (ie service desk) staff to help users
+be added to the necesary security groups within reason.
+
+* read all groups
+* write group but not high access
+
+Admins
+======
+
+These are the people who deploy and manage the server. It's important that they have the ability
+to recover the system in DR scenarios, manage the technical implementation and deployment of
+the instance, that they can grant privileges to other groups, and they
+must bootstrap the initial deployment out of the box.
+
+With this in mind, unlike other systems, admins do not have *unlimited* scope of power and access
+by default, but they are able to escalate to have *unlimited* power. This group as a result should
+be highly controlled and limited to "need to access" basis, and only providing claims when required.
+For the reasons stated, this is considered a "high access" account.
+
+* read and write access control entries.
+* read and write schema entries.
+* modify all groups including high access groups.
+* create new accounts (to bootstrap the system).
+* modify high access accounts as an escalation for security sensitive accounts.
+* recover from the recycle bin
+
+People Managers
+===============
+
+These are the people who require the ability to read or write to private and sensitive data of
+peoples accounts. It's important to consider this will become two privileges, one for read, one
+for write.
+
+Due to dealing with potentially private or sensitive information, this is a "high access" account.
+
+* read private or sensitive data of persons, IE legalName
+* write privare or sensitive data of persons, IE legalName
+
+Remember, this role does NOT allow technical changes, IE password changes or normal technical changes.
+
+Anonymous Clients + Everyone Else
+=================================
+
+These are clients that do not authenticate to the service, or have authenticated and we need to show
+a default set of reasonable public information about the account.
+Common examples would be unix servers, applications, idm proxies, email
+clients as anonymous users, and all the others listed groups here would be authenticated and require
+the basic read capabilities.
+
+As a result, we have to only allow the *minimum* information to be access that is required for those
+clients to run. We focus on the unix client anonymous needs in this case, and may add
+other anonymous read types later as we understand different applications people choose to deploy
+with the system.
+
+* read memberof, unix attrs, name, displayname, class
+
+RADIUS Servers
+==============
+
+Radius servers are a special class of application because they need to read security sensitive
+credentials from the server. Due to the historical challenges of deploying radius, this role
+should exist by default.
+
+Due to the handling of credentials, this is a "high access" group.
+
+* Read radius credentials
+* Read other needed attributes to fufil radius functions.
+
+External Account Systems
+========================
+
+External accounts systems generally provide a feed of data to the IDM system to then perform actions
+such as account creation, deletion and modification. You could consider a HR system, or even a
+web portal for self sign up as this type of system.
+
+As a result, this has some more complex possible interactions. A HR system may need full account
+and group management rights including private data modification. Another system could be to
+sync from another IDM but only requires non-sensitive data types so may just need group and
+other access. Finally, a web portal for a user to self-sign up may only need account creation
+rights.
+
+It's important to note, that in this ACI that high access groups should *not* be modifiable.
+
+This is a "high access" role due to the scope for account manipulation and damage if misused.

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -86,9 +86,8 @@ fn test_server_create() {
         let e: Entry = serde_json::from_str(
             r#"{
             "attrs": {
-                "class": ["person"],
+                "class": ["person", "account"],
                 "name": ["testperson"],
-                "description": ["testperson"],
                 "displayname": ["testperson"]
             }
         }"#,

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -149,22 +149,27 @@ fn test_server_whoami_admin_simple_password() {
     });
 }
 
-// Test hitting all auth-required endpoints and assert they give unauthorized.
-
-/*
 #[test]
-fn test_be_create_user() {
-    run_test!(|log, server: actix::Addr<QueryServer>| {
-        let r1 = server.search();
-        assert!(r1.len() == 0);
+fn test_server_search() {
+    run_test(|rsclient: KanidmClient| {
+        // First show we are un-authenticated.
+        let pre_res = rsclient.whoami();
+        // This means it was okay whoami, but no uat attached.
+        assert!(pre_res.unwrap().is_none());
 
-        let cr = server.create();
-        assert!(cr.is_ok());
+        let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
+        assert!(res.is_ok());
 
-        let r2 = server.search();
-        assert!(r2.len() == 1);
-
-        future::ok(())
+        let rset = rsclient
+            .search_str("{\"Eq\":[\"name\", \"admin\"]}")
+            .unwrap();
+        println!("{:?}", rset);
+        let e = rset.first().unwrap();
+        // Check it's admin.
+        println!("{:?}", e);
+        let name = e.attrs.get("name").unwrap();
+        assert!(name == &vec!["admin".to_string()]);
     });
 }
-*/
+
+// Test hitting all auth-required endpoints and assert they give unauthorized.

--- a/kanidmd/src/lib/constants.rs
+++ b/kanidmd/src/lib/constants.rs
@@ -177,7 +177,8 @@ pub static JSON_IDM_HP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 
-pub static _UUID_IDM_SERVICE_ACCOUNT_CREATE_PRIV: &'static str = "00000000-0000-0000-0000-000000000013";
+pub static _UUID_IDM_SERVICE_ACCOUNT_CREATE_PRIV: &'static str =
+    "00000000-0000-0000-0000-000000000013";
 pub static JSON_IDM_SERVICE_ACCOUNT_CREATE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -188,7 +189,8 @@ pub static JSON_IDM_SERVICE_ACCOUNT_CREATE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 
-pub static _UUID_IDM_PERSON_ACCOUNT_CREATE_PRIV: &'static str = "00000000-0000-0000-0000-000000000014";
+pub static _UUID_IDM_PERSON_ACCOUNT_CREATE_PRIV: &'static str =
+    "00000000-0000-0000-0000-000000000014";
 pub static JSON_IDM_PERSON_ACCOUNT_CREATE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -283,7 +285,8 @@ pub static JSON_IDM_ACP_XX_V1: &'static str = r#"{
 }"#;
 */
 
-pub static _UUID_IDM_ADMINS_ACP_RECYCLE_SEARCH_V1: &'static str = "00000000-0000-0000-0000-ffffff000002";
+pub static _UUID_IDM_ADMINS_ACP_RECYCLE_SEARCH_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000002";
 pub static JSON_IDM_ADMINS_ACP_RECYCLE_SEARCH_V1: &'static str = r#"{
     "attrs": {
         "class": ["object", "access_control_profile", "access_control_search"],
@@ -403,7 +406,6 @@ pub static JSON_IDM_ALL_ACP_READ_V1: &'static str = r#"{
     }
 }"#;
 
-
 // 7 people read acp JSON_IDM_PEOPLE_READ_PRIV_V1
 pub static _UUID_IDM_ACP_PEOPLE_READ_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000007";
 pub static JSON_IDM_ACP_PEOPLE_READ_PRIV_V1: &'static str = r#"{
@@ -429,7 +431,8 @@ pub static JSON_IDM_ACP_PEOPLE_READ_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 8 people write acp JSON_IDM_PEOPLE_WRITE_PRIV_V1
-pub static _UUID_IDM_ACP_PEOPLE_WRITE_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000008";
+pub static _UUID_IDM_ACP_PEOPLE_WRITE_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000008";
 pub static JSON_IDM_ACP_PEOPLE_WRITE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -488,7 +491,8 @@ pub static JSON_IDM_ACP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 10 account read acp JSON_IDM_ACCOUNT_READ_PRIV_V1
-pub static _UUID_IDM_ACP_ACCOUNT_READ_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000010";
+pub static _UUID_IDM_ACP_ACCOUNT_READ_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000010";
 pub static JSON_IDM_ACP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -512,7 +516,8 @@ pub static JSON_IDM_ACP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 11 account write acp JSON_IDM_ACCOUNT_WRITE_PRIV_V1
-pub static _UUID_IDM_ACP_ACCOUNT_WRITE_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000011";
+pub static _UUID_IDM_ACP_ACCOUNT_WRITE_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000011";
 pub static JSON_IDM_ACP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -539,7 +544,8 @@ pub static JSON_IDM_ACP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 12 service account create acp (only admins?)  JSON_IDM_SERVICE_ACCOUNT_CREATE_PRIV_V1
-pub static _UUID_IDM_ACP_SERVICE_ACCOUNT_CREATE_V1: &'static str = "00000000-0000-0000-0000-ffffff000012";
+pub static _UUID_IDM_ACP_SERVICE_ACCOUNT_CREATE_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000012";
 pub static JSON_IDM_ACP_SERVICE_ACCOUNT_CREATE_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -569,7 +575,8 @@ pub static JSON_IDM_ACP_SERVICE_ACCOUNT_CREATE_V1: &'static str = r#"{
     }
 }"#;
 // 13 user (person) account create acp  JSON_IDM_PERSON_ACCOUNT_CREATE_PRIV_V1
-pub static _UUID_IDM_ACP_PERSON_ACCOUNT_CREATE_V1: &'static str = "00000000-0000-0000-0000-ffffff000013";
+pub static _UUID_IDM_ACP_PERSON_ACCOUNT_CREATE_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000013";
 pub static JSON_IDM_ACP_PERSON_ACCOUNT_CREATE_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -629,7 +636,8 @@ pub static JSON_IDM_ACP_RADIUS_SERVERS_V1: &'static str = r#"{
     }
 }"#;
 // 15 high priv account read JSON_IDM_HP_ACCOUNT_READ_PRIV_V1
-pub static _UUID_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000015";
+pub static _UUID_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000015";
 pub static JSON_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -653,7 +661,8 @@ pub static JSON_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 16 high priv account write JSON_IDM_HP_ACCOUNT_WRITE_PRIV_V1
-pub static _UUID_IDM_ACP_HP_ACCOUNT_WRITE_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000016";
+pub static _UUID_IDM_ACP_HP_ACCOUNT_WRITE_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000016";
 pub static JSON_IDM_ACP_HP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -682,7 +691,8 @@ pub static JSON_IDM_ACP_HP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
 }"#;
 
 // 17 high priv group write --> JSON_IDM_HP_GROUP_WRITE_PRIV_V1 (12)
-pub static _UUID_IDM_ACP_HP_GROUP_WRITE_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000017";
+pub static _UUID_IDM_ACP_HP_GROUP_WRITE_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000017";
 pub static JSON_IDM_ACP_HP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -715,7 +725,8 @@ pub static JSON_IDM_ACP_HP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
 }"#;
 
 // 18 schema write JSON_IDM_SCHEMA_WRITE_PRIV_V1
-pub static _UUID_IDM_ACP_SCHEMA_WRITE_ATTRS_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000018";
+pub static _UUID_IDM_ACP_SCHEMA_WRITE_ATTRS_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000018";
 pub static JSON_IDM_ACP_SCHEMA_WRITE_ATTRS_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -776,7 +787,8 @@ pub static JSON_IDM_ACP_SCHEMA_WRITE_ATTRS_PRIV_V1: &'static str = r#"{
     }
 }"#;
 
-pub static _UUID_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000019";
+pub static _UUID_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000019";
 pub static JSON_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -929,7 +941,6 @@ pub static JSON_IDM_ACP_ACP_MANAGER_PRIV_V1: &'static str = r#"{
 }"#;
 
 // 20 - anonymous / everyone schema read.
-
 
 // Anonymous should be the last opbject in the range here.
 pub static JSON_ANONYMOUS_V1: &'static str = r#"{

--- a/kanidmd/src/lib/constants.rs
+++ b/kanidmd/src/lib/constants.rs
@@ -789,64 +789,6 @@ pub static JSON_IDM_ACP_SCHEMA_WRITE_ATTRS_PRIV_V1: &'static str = r#"{
     }
 }"#;
 
-pub static _UUID_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000019";
-pub static JSON_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &'static str = r#"{
-    "attrs": {
-        "class": [
-            "object",
-            "access_control_profile",
-            "access_control_search",
-            "access_control_modify",
-            "access_control_create"
-        ],
-        "name": ["idm_acp_schema_write_classes_priv"],
-        "uuid": ["00000000-0000-0000-0000-ffffff000019"],
-        "description": ["Builtin IDM Control for management of schema classes."],
-        "acp_enable": ["true"],
-        "acp_receiver": [
-            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000010\"]}"
-        ],
-        "acp_targetscope": [
-            "{\"And\": [{\"Eq\": [\"class\",\"classtype\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
-        ],
-        "acp_search_attr": [
-            "class",
-            "description",
-            "classname",
-            "systemmay",
-            "may",
-            "systemmust",
-            "must",
-            "uuid"
-        ],
-        "acp_modify_removedattr": [
-            "class",
-            "description",
-            "may",
-            "must"
-        ],
-        "acp_modify_presentattr": [
-            "class",
-            "description",
-            "may",
-            "must"
-        ],
-        "acp_modify_class":  [],
-        "acp_create_attr": [
-            "class",
-            "description",
-            "classname",
-            "may",
-            "must",
-            "uuid"
-        ],
-        "acp_create_class": [
-            "object", "classtype"
-        ]
-    }
-}"#;
-
 // 19 acp read/write
 pub static _UUID_IDM_ACP_ACP_MANAGER_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000019";
 pub static JSON_IDM_ACP_ACP_MANAGER_PRIV_V1: &'static str = r#"{
@@ -942,7 +884,65 @@ pub static JSON_IDM_ACP_ACP_MANAGER_PRIV_V1: &'static str = r#"{
     }
 }"#;
 
-// 20 - anonymous / everyone schema read.
+pub static _UUID_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000020";
+pub static JSON_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_search",
+            "access_control_modify",
+            "access_control_create"
+        ],
+        "name": ["idm_acp_schema_write_classes_priv"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000020"],
+        "description": ["Builtin IDM Control for management of schema classes."],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000010\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Eq\": [\"class\",\"classtype\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_search_attr": [
+            "class",
+            "description",
+            "classname",
+            "systemmay",
+            "may",
+            "systemmust",
+            "must",
+            "uuid"
+        ],
+        "acp_modify_removedattr": [
+            "class",
+            "description",
+            "may",
+            "must"
+        ],
+        "acp_modify_presentattr": [
+            "class",
+            "description",
+            "may",
+            "must"
+        ],
+        "acp_modify_class":  [],
+        "acp_create_attr": [
+            "class",
+            "description",
+            "classname",
+            "may",
+            "must",
+            "uuid"
+        ],
+        "acp_create_class": [
+            "object", "classtype"
+        ]
+    }
+}"#;
+
+// 21 - anonymous / everyone schema read.
 
 // Anonymous should be the last opbject in the range here.
 pub static JSON_ANONYMOUS_V1: &'static str = r#"{

--- a/kanidmd/src/lib/constants.rs
+++ b/kanidmd/src/lib/constants.rs
@@ -564,6 +564,7 @@ pub static JSON_IDM_ACP_SERVICE_ACCOUNT_CREATE_V1: &'static str = r#"{
             "{\"And\": [{\"Eq\": [\"class\",\"account\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
         ],
         "acp_create_attr": [
+            "class",
             "name",
             "displayname",
             "primary_credential",
@@ -592,9 +593,10 @@ pub static JSON_IDM_ACP_PERSON_ACCOUNT_CREATE_V1: &'static str = r#"{
             "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000014\"]}"
         ],
         "acp_targetscope": [
-            "{\"And\": [{\"Eq\": [\"class\",\"account\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+            "{\"And\": [{\"Eq\": [\"class\",\"account\"]}, {\"Eq\": [\"class\",\"person\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
         ],
         "acp_create_attr": [
+            "class",
             "name",
             "displayname",
             "legalname",

--- a/kanidmd/src/lib/constants.rs
+++ b/kanidmd/src/lib/constants.rs
@@ -47,12 +47,188 @@ pub static JSON_IDM_ADMINS_V1: &'static str = r#"{
     }
 }"#;
 
+// groups
+// * People read managers
+pub static _UUID_IDM_PEOPLE_READ_PRIV: &'static str = "00000000-0000-0000-0000-000000000002";
+pub static JSON_IDM_PEOPLE_READ_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": ["group", "object"],
+        "name": ["idm_people_read_priv"],
+        "uuid": ["00000000-0000-0000-0000-000000000002"],
+        "description": ["Builtin IDM Group for granting elevated people (personal data) read permissions."],
+        "member": ["00000000-0000-0000-0000-000000000003"]
+    }
+}"#;
+// * People write managers
+pub static _UUID_IDM_PEOPLE_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000003";
+pub static JSON_IDM_PEOPLE_WRITE_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": ["group", "object"],
+        "name": ["idm_people_write_priv"],
+        "uuid": ["00000000-0000-0000-0000-000000000003"],
+        "description": ["Builtin IDM Group for granting elevated people (personal data) write permissions."]
+    }
+}"#;
+// * group write manager (no read, everyone has read via the anon, etc)
+pub static _UUID_IDM_GROUP_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000004";
+pub static JSON_IDM_GROUP_WRITE_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": ["group", "object"],
+        "name": ["idm_group_write_priv"],
+        "uuid": ["00000000-0000-0000-0000-000000000004"],
+        "description": ["Builtin IDM Group for granting elevated group write permissions."],
+        "member": ["00000000-0000-0000-0000-000000000001"]
+    }
+}"#;
+// * account read manager
+pub static _UUID_IDM_ACCOUNT_READ_PRIV: &'static str = "00000000-0000-0000-0000-000000000005";
+pub static JSON_IDM_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": ["group", "object"],
+        "name": ["idm_account_read_priv"],
+        "uuid": ["00000000-0000-0000-0000-000000000005"],
+        "description": ["Builtin IDM Group for granting elevated account read permissions."],
+        "member": [
+            "00000000-0000-0000-0000-000000000006",
+            "00000000-0000-0000-0000-000000000001"
+        ]
+    }
+}"#;
+// * account write manager
+pub static _UUID_IDM_ACCOUNT_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000006";
+pub static JSON_IDM_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": ["group", "object"],
+        "name": ["idm_account_write_priv"],
+        "uuid": ["00000000-0000-0000-0000-000000000006"],
+        "description": ["Builtin IDM Group for granting elevated account write permissions."]
+    }
+}"#;
+// * RADIUS servers
+pub static _UUID_IDM_RADIUS_SERVERS: &'static str = "00000000-0000-0000-0000-000000000007";
+pub static JSON_IDM_RADIUS_SERVERS_V1: &'static str = r#"{
+    "attrs": {
+        "class": ["group", "object"],
+        "name": ["idm_radius_servers"],
+        "uuid": ["00000000-0000-0000-0000-000000000007"],
+        "description": ["Builtin IDM Group for RADIUS server access delegation."]
+    }
+}"#;
+// * high priv account read manager
+pub static _UUID_IDM_HP_ACCOUNT_READ_PRIV: &'static str = "00000000-0000-0000-0000-000000000008";
+pub static JSON_IDM_HP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": ["group", "object"],
+        "name": ["idm_hp_account_read_priv"],
+        "uuid": ["00000000-0000-0000-0000-000000000008"],
+        "description": ["Builtin IDM Group for granting elevated account read permissions over high privilege accounts."],
+        "member": [
+            "00000000-0000-0000-0000-000000000001",
+            "00000000-0000-0000-0000-000000000009"
+        ]
+    }
+}"#;
+// * high priv account write manager
+pub static _UUID_IDM_HP_ACCOUNT_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000009";
+pub static JSON_IDM_HP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": ["group", "object"],
+        "name": ["idm_hp_account_write_priv"],
+        "uuid": ["00000000-0000-0000-0000-000000000009"],
+        "description": ["Builtin IDM Group for granting elevated account write permissions over high privilege accounts."],
+        "member": [
+            "00000000-0000-0000-0000-000000000001"
+        ]
+    }
+}"#;
+// * Schema write manager
+pub static _UUID_IDM_SCHEMA_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000010";
+pub static JSON_IDM_SCHEMA_WRITE_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": ["group", "object"],
+        "name": ["idm_schema_write_priv"],
+        "uuid": ["00000000-0000-0000-0000-000000000010"],
+        "description": ["Builtin IDM Group for granting elevated schema write permissions."],
+        "member": [
+            "00000000-0000-0000-0000-000000000001"
+        ]
+    }
+}"#;
+// * ACP read/write manager
+pub static _UUID_IDM_ACP_MANAGER_PRIV: &'static str = "00000000-0000-0000-0000-000000000011";
+pub static JSON_IDM_ACP_MANAGER_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": ["group", "object"],
+        "name": ["idm_acp_manager_priv"],
+        "uuid": ["00000000-0000-0000-0000-000000000011"],
+        "description": ["Builtin IDM Group for granting control over all access control profile modifications."],
+        "member": ["00000000-0000-0000-0000-000000000001"]
+    }
+}"#;
+
+pub static _UUID_IDM_HP_GROUP_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000009";
+pub static JSON_IDM_HP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": ["group", "object"],
+        "name": ["idm_hp_group_write_priv"],
+        "uuid": ["00000000-0000-0000-0000-000000000012"],
+        "description": ["Builtin IDM Group for granting elevated group write privileges for high privilege groups."],
+        "member": ["00000000-0000-0000-0000-000000000001"]
+    }
+}"#;
+
+pub static _UUID_IDM_SERVICE_ACCOUNT_CREATE_PRIV: &'static str = "00000000-0000-0000-0000-000000000013";
+pub static JSON_IDM_SERVICE_ACCOUNT_CREATE_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": ["group", "object"],
+        "name": ["idm_service_account_create_priv"],
+        "uuid": ["00000000-0000-0000-0000-000000000013"],
+        "description": ["Builtin IDM Group for granting service account creation rights"],
+        "member": ["00000000-0000-0000-0000-000000000001"]
+    }
+}"#;
+
+pub static _UUID_IDM_PERSON_ACCOUNT_CREATE_PRIV: &'static str = "00000000-0000-0000-0000-000000000014";
+pub static JSON_IDM_PERSON_ACCOUNT_CREATE_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": ["group", "object"],
+        "name": ["idm_person_account_create_priv"],
+        "uuid": ["00000000-0000-0000-0000-000000000014"],
+        "description": ["Builtin IDM Group for granting person/account creation rights"],
+        "member": ["00000000-0000-0000-0000-000000000001"]
+    }
+}"#;
+
+// This must be the last group to init to include the UUID of the other high priv groups.
+pub static _UUID_IDM_HIGH_PRIVILEGE: &'static str = "00000000-0000-0000-0000-000000001000";
+pub static JSON_IDM_HIGH_PRIVILEGE_V1: &'static str = r#"{
+    "attrs": {
+        "class": ["group", "object"],
+        "name": ["idm_high_privilege"],
+        "uuid": ["00000000-0000-0000-0000-000000001000"],
+        "description": ["Builtin IDM provided groups with high levels of access that should be audited and limited in modification."],
+        "member": [
+            "00000000-0000-0000-0000-000000000001",
+            "00000000-0000-0000-0000-000000000002",
+            "00000000-0000-0000-0000-000000000003",
+            "00000000-0000-0000-0000-000000000004",
+            "00000000-0000-0000-0000-000000000005",
+            "00000000-0000-0000-0000-000000000006",
+            "00000000-0000-0000-0000-000000000007",
+            "00000000-0000-0000-0000-000000000008",
+            "00000000-0000-0000-0000-000000000009",
+            "00000000-0000-0000-0000-000000000010",
+            "00000000-0000-0000-0000-000000000011",
+            "00000000-0000-0000-0000-000000000012",
+            "00000000-0000-0000-0000-000000000013",
+            "00000000-0000-0000-0000-000000000014",
+            "00000000-0000-0000-0000-000000001000"
+        ]
+    }
+}"#;
+
 pub static _UUID_SYSTEM_INFO: &'static str = "00000000-0000-0000-0000-ffffff000001";
 pub static JSON_SYSTEM_INFO_V1: &'static str = r#"{
-    "valid": {
-        "uuid": "00000000-0000-0000-0000-ffffff000001"
-    },
-    "state": null,
     "attrs": {
         "class": ["object", "system_info"],
         "uuid": ["00000000-0000-0000-0000-ffffff000001"],
@@ -62,34 +238,71 @@ pub static JSON_SYSTEM_INFO_V1: &'static str = r#"{
     }
 }"#;
 
-pub static _UUID_IDM_ADMINS_ACP_SEARCH_V1: &'static str = "00000000-0000-0000-0000-ffffff000002";
-pub static JSON_IDM_ADMINS_ACP_SEARCH_V1: &'static str = r#"{
-    "valid": {
-        "uuid": "00000000-0000-0000-0000-ffffff000002"
-    },
-    "state": null,
+/*
+// Template acp
+pub static _UUID_IDM_ACP_XX_V1: &'static str = "00000000-0000-0000-0000-ffffff0000XX";
+pub static JSON_IDM_ACP_XX_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_search",
+            "access_control_modify",
+            "access_control_create",
+            "access_control_delete"
+        ],
+        "name": ["idm_acp_xx"],
+        "uuid": ["00000000-0000-0000-0000-ffffff0000XX"],
+        "description": ["Builtin IDM Control for xx"],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-0000000000XX\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Eq\": [\"attr\",\"value\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_search_attr": [
+
+        ],
+        "acp_modify_removedattr": [
+
+        ],
+        "acp_modify_presentattr": [
+
+        ],
+        "acp_modify_class":  [
+
+        ],
+        "acp_create_attr": [
+
+        ],
+        "acp_create_class": [
+
+        ]
+    }
+}"#;
+*/
+
+pub static _UUID_IDM_ADMINS_ACP_RECYCLE_SEARCH_V1: &'static str = "00000000-0000-0000-0000-ffffff000002";
+pub static JSON_IDM_ADMINS_ACP_RECYCLE_SEARCH_V1: &'static str = r#"{
     "attrs": {
         "class": ["object", "access_control_profile", "access_control_search"],
-        "name": ["idm_admins_acp_search"],
+        "name": ["idm_admins_acp_recycle_search"],
         "uuid": ["00000000-0000-0000-0000-ffffff000002"],
-        "description": ["Builtin IDM Administrators Access Controls."],
+        "description": ["Builtin IDM admin recycle bin search permission."],
         "acp_enable": ["true"],
         "acp_receiver": [
             "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000001\"]}"
         ],
         "acp_targetscope": [
-            "{\"Pres\":\"class\"}"
+            "{\"Eq\": [\"class\", \"recycled\"]}"
         ],
-        "acp_search_attr": ["name", "class", "uuid", "description", "displayname"]
+        "acp_search_attr": ["name", "class", "uuid"]
     }
 }"#;
 
 pub static _UUID_IDM_ADMINS_ACP_REVIVE_V1: &'static str = "00000000-0000-0000-0000-ffffff000003";
 pub static JSON_IDM_ADMINS_ACP_REVIVE_V1: &'static str = r#"{
-    "valid": {
-        "uuid": "00000000-0000-0000-0000-ffffff000003"
-    },
-    "state": null,
     "attrs": {
         "class": ["object", "access_control_profile", "access_control_modify"],
         "name": ["idm_admins_acp_revive"],
@@ -109,15 +322,11 @@ pub static JSON_IDM_ADMINS_ACP_REVIVE_V1: &'static str = r#"{
 
 pub static _UUID_IDM_SELF_ACP_READ_V1: &'static str = "00000000-0000-0000-0000-ffffff000004";
 pub static JSON_IDM_SELF_ACP_READ_V1: &'static str = r#"{
-    "valid": {
-        "uuid": "00000000-0000-0000-0000-ffffff000004"
-    },
-    "state": null,
     "attrs": {
         "class": ["object", "access_control_profile", "access_control_search"],
         "name": ["idm_self_acp_read"],
         "uuid": ["00000000-0000-0000-0000-ffffff000004"],
-        "description": ["Builtin IDM Control for self read - required for whoami."],
+        "description": ["Builtin IDM Control for self read - required for whoami and many other functions."],
         "acp_enable": ["true"],
         "acp_receiver": [
             "\"Self\""
@@ -125,16 +334,21 @@ pub static JSON_IDM_SELF_ACP_READ_V1: &'static str = r#"{
         "acp_targetscope": [
             "\"Self\""
         ],
-        "acp_search_attr": ["name", "uuid"]
+        "acp_search_attr": [
+            "name",
+            "displayname",
+            "legalname",
+            "class",
+            "memberof",
+            "member",
+            "uuid"
+        ]
     }
 }"#;
 
+/*
 pub static _UUID_IDM_ADMINS_ACP_MANAGE_V1: &'static str = "00000000-0000-0000-0000-ffffff000005";
 pub static JSON_IDM_ADMINS_ACP_MANAGE_V1: &'static str = r#"{
-    "valid": {
-        "uuid": "00000000-0000-0000-0000-ffffff000005"
-    },
-    "state": null,
     "attrs": {
         "class": [
             "object",
@@ -152,7 +366,7 @@ pub static JSON_IDM_ADMINS_ACP_MANAGE_V1: &'static str = r#"{
             "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000001\"]}"
         ],
         "acp_targetscope": [
-            "{\"Pres\":\"class\"}"
+            "{\"And\": [{\"Pres\": \"class\"}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
         ],
         "acp_search_attr": ["name", "class", "uuid", "classname", "attributename", "memberof"],
         "acp_modify_class": ["person"],
@@ -162,12 +376,563 @@ pub static JSON_IDM_ADMINS_ACP_MANAGE_V1: &'static str = r#"{
         "acp_create_attr": ["name", "class", "description", "displayname"]
     }
 }"#;
+*/
 
-pub static JSON_ANONYMOUS_V1: &'static str = r#"{
-    "valid": {
-        "uuid": "00000000-0000-0000-0000-ffffffffffff"
-    },
+pub static _UUID_IDM_ALL_ACP_READ_V1: &'static str = "00000000-0000-0000-0000-ffffff000006";
+pub static JSON_IDM_ALL_ACP_READ_V1: &'static str = r#"{
     "state": null,
+    "attrs": {
+        "class": ["object", "access_control_profile", "access_control_search"],
+        "name": ["idm_all_acp_read"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000006"],
+        "description": ["Builtin IDM Control for all read - IE anonymous and all authenticated accounts."],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Pres\":\"class\"}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Pres\": \"class\"}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_search_attr": [
+            "name",
+            "displayname",
+            "class",
+            "memberof",
+            "member"
+        ]
+    }
+}"#;
+
+
+// 7 people read acp JSON_IDM_PEOPLE_READ_PRIV_V1
+pub static _UUID_IDM_ACP_PEOPLE_READ_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000007";
+pub static JSON_IDM_ACP_PEOPLE_READ_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_search"
+        ],
+        "name": ["idm_acp_people_read_priv"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000007"],
+        "description": ["Builtin IDM Control for reading personal sensitive data."],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000002\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Eq\": [\"class\",\"account\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"memberof\",\"00000000-0000-0000-0000-000000001000\"]}, {\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_search_attr": [
+            "name", "displayname", "legalname", "mail"
+        ]
+    }
+}"#;
+// 8 people write acp JSON_IDM_PEOPLE_WRITE_PRIV_V1
+pub static _UUID_IDM_ACP_PEOPLE_WRITE_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000008";
+pub static JSON_IDM_ACP_PEOPLE_WRITE_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_modify"
+        ],
+        "name": ["idm_acp_people_write_priv"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000008"],
+        "description": ["Builtin IDM Control for managing personal and sensitive data."],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000003\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Eq\": [\"class\",\"person\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"memberof\",\"00000000-0000-0000-0000-000000001000\"]}, {\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_modify_removedattr": [
+            "name", "displayname", "legalname", "mail"
+        ],
+        "acp_modify_presentattr": [
+            "name", "displayname", "legalname", "mail"
+        ]
+    }
+}"#;
+// 9 group write acp JSON_IDM_GROUP_WRITE_PRIV_V1
+pub static _UUID_IDM_ACP_GROUP_WRITE_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000009";
+pub static JSON_IDM_ACP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_search",
+            "access_control_modify",
+            "access_control_delete"
+        ],
+        "name": ["idm_acp_group_write_priv"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000009"],
+        "description": ["Builtin IDM Control for managing groups"],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000004\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Eq\": [\"class\",\"group\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"memberof\",\"00000000-0000-0000-0000-000000001000\"]}, {\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_search_attr": [
+            "class", "name", "uuid", "description", "member"
+        ],
+        "acp_modify_removedattr": [
+            "name", "description", "member"
+        ],
+        "acp_modify_presentattr": [
+            "name", "description", "member"
+        ]
+    }
+}"#;
+// 10 account read acp JSON_IDM_ACCOUNT_READ_PRIV_V1
+pub static _UUID_IDM_ACP_ACCOUNT_READ_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000010";
+pub static JSON_IDM_ACP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_search"
+        ],
+        "name": ["idm_acp_account_read_priv"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000010"],
+        "description": ["Builtin IDM Control for accounts."],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000005\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Eq\": [\"class\",\"account\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"memberof\",\"00000000-0000-0000-0000-000000001000\"]}, {\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_search_attr": [
+            "class", "name", "uuid", "displayname", "ssh_publickey", "primary_credential", "memberof", "mail"
+        ]
+    }
+}"#;
+// 11 account write acp JSON_IDM_ACCOUNT_WRITE_PRIV_V1
+pub static _UUID_IDM_ACP_ACCOUNT_WRITE_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000011";
+pub static JSON_IDM_ACP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_modify"
+        ],
+        "name": ["idm_acp_account_write_priv"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000011"],
+        "description": ["Builtin IDM Control for managing accounts."],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000006\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Eq\": [\"class\",\"account\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"memberof\",\"00000000-0000-0000-0000-000000001000\"]}, {\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_modify_removedattr": [
+            "name", "displayname", "ssh_publickey", "primary_credential", "mail"
+        ],
+        "acp_modify_presentattr": [
+            "name", "displayname", "ssh_publickey", "primary_credential", "mail"
+        ]
+    }
+}"#;
+// 12 service account create acp (only admins?)  JSON_IDM_SERVICE_ACCOUNT_CREATE_PRIV_V1
+pub static _UUID_IDM_ACP_SERVICE_ACCOUNT_CREATE_V1: &'static str = "00000000-0000-0000-0000-ffffff000012";
+pub static JSON_IDM_ACP_SERVICE_ACCOUNT_CREATE_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_create"
+        ],
+        "name": ["idm_acp_service_account_create"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000012"],
+        "description": ["Builtin IDM Control for creating person (user) accounts"],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000013\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Eq\": [\"class\",\"account\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_create_attr": [
+            "name",
+            "displayname",
+            "primary_credential",
+            "ssh_publickey"
+        ],
+        "acp_create_class": [
+            "object", "account"
+        ]
+    }
+}"#;
+// 13 user (person) account create acp  JSON_IDM_PERSON_ACCOUNT_CREATE_PRIV_V1
+pub static _UUID_IDM_ACP_PERSON_ACCOUNT_CREATE_V1: &'static str = "00000000-0000-0000-0000-ffffff000013";
+pub static JSON_IDM_ACP_PERSON_ACCOUNT_CREATE_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_create"
+        ],
+        "name": ["idm_acp_person_account_create"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000013"],
+        "description": ["Builtin IDM Control for creating person (user) accounts"],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000014\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Eq\": [\"class\",\"account\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_create_attr": [
+            "name",
+            "displayname",
+            "legalname",
+            "primary_credential",
+            "ssh_publickey",
+            "mail"
+        ],
+        "acp_create_class": [
+            "object", "person", "account"
+        ]
+    }
+}"#;
+
+// 14 radius read acp JSON_IDM_RADIUS_SERVERS_V1
+pub static _UUID_IDM_ACP_RADIUS_SERVERS_V1: &'static str = "00000000-0000-0000-0000-ffffff000014";
+// The targetscope of this could change later to a "radius access" group or similar so we can add/remove
+//  users from having radius access easier.
+// TODO #17: Add the radius credential type that we need to read here.
+pub static JSON_IDM_ACP_RADIUS_SERVERS_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_search"
+        ],
+        "name": ["idm_acp_radius_servers"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000014"],
+        "description": ["Builtin IDM Control for RADIUS servers to read credentials and other needed details."],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000007\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Pres\": \"class\"}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_search_attr": [
+            "name", "uuid"
+        ]
+    }
+}"#;
+// 15 high priv account read JSON_IDM_HP_ACCOUNT_READ_PRIV_V1
+pub static _UUID_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000015";
+pub static JSON_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_search"
+        ],
+        "name": ["idm_acp_hp_account_read_priv"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000015"],
+        "description": ["Builtin IDM Control for reading high privilege accounts."],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000009\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Eq\": [\"class\",\"account\"]}, {\"Eq\": [\"memberof\",\"00000000-0000-0000-0000-000000001000\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_search_attr": [
+            "class", "name", "uuid", "displayname", "ssh_publickey", "primary_credential", "memberof"
+        ]
+    }
+}"#;
+// 16 high priv account write JSON_IDM_HP_ACCOUNT_WRITE_PRIV_V1
+pub static _UUID_IDM_ACP_HP_ACCOUNT_WRITE_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000016";
+pub static JSON_IDM_ACP_HP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_modify",
+            "access_control_delete"
+        ],
+        "name": ["idm_acp_hp_account_write_priv"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000016"],
+        "description": ["Builtin IDM Control for managing high privilege accounts."],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000009\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Eq\": [\"class\",\"account\"]}, {\"Eq\": [\"memberof\",\"00000000-0000-0000-0000-000000001000\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_modify_removedattr": [
+            "name", "displayname", "ssh_publickey", "primary_credential"
+        ],
+        "acp_modify_presentattr": [
+            "name", "displayname", "ssh_publickey", "primary_credential"
+        ]
+    }
+}"#;
+
+// 17 high priv group write --> JSON_IDM_HP_GROUP_WRITE_PRIV_V1 (12)
+pub static _UUID_IDM_ACP_HP_GROUP_WRITE_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000017";
+pub static JSON_IDM_ACP_HP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_search",
+            "access_control_modify",
+            "access_control_delete"
+        ],
+        "name": ["idm_acp_hp_group_write_priv"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000017"],
+        "description": ["Builtin IDM Control for managing high privilege groups"],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000012\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Eq\": [\"class\",\"group\"]}, {\"Eq\": [\"memberof\",\"00000000-0000-0000-0000-000000001000\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_search_attr": [
+            "class", "name", "uuid", "description", "member"
+        ],
+        "acp_modify_removedattr": [
+            "name", "description", "member"
+        ],
+        "acp_modify_presentattr": [
+            "name", "description", "member"
+        ]
+    }
+}"#;
+
+// 18 schema write JSON_IDM_SCHEMA_WRITE_PRIV_V1
+pub static _UUID_IDM_ACP_SCHEMA_WRITE_ATTRS_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000018";
+pub static JSON_IDM_ACP_SCHEMA_WRITE_ATTRS_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_search",
+            "access_control_modify",
+            "access_control_create"
+        ],
+        "name": ["idm_acp_schema_write_attrs_priv"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000018"],
+        "description": ["Builtin IDM Control for management of schema attributes."],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000010\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Eq\": [\"class\",\"attributetype\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_search_attr": [
+            "class",
+            "description",
+            "index",
+            "unique",
+            "multivalue",
+            "attributename",
+            "syntax",
+            "uuid"
+        ],
+        "acp_modify_removedattr": [
+            "description",
+            "index",
+            "unique",
+            "multivalue",
+            "syntax"
+        ],
+        "acp_modify_presentattr": [
+            "description",
+            "index",
+            "unique",
+            "multivalue",
+            "syntax"
+        ],
+        "acp_modify_class":  [],
+        "acp_create_attr": [
+            "class",
+            "description",
+            "index",
+            "unique",
+            "multivalue",
+            "attributename",
+            "syntax",
+            "uuid"
+        ],
+        "acp_create_class": [
+            "object", "attributetype"
+        ]
+    }
+}"#;
+
+pub static _UUID_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000019";
+pub static JSON_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_search",
+            "access_control_modify",
+            "access_control_create"
+        ],
+        "name": ["idm_acp_schema_write_classes_priv"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000019"],
+        "description": ["Builtin IDM Control for management of schema classes."],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000010\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Eq\": [\"class\",\"classtype\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_search_attr": [
+            "class",
+            "description",
+            "classname",
+            "systemmay",
+            "may",
+            "systemmust",
+            "must",
+            "uuid"
+        ],
+        "acp_modify_removedattr": [
+            "class",
+            "description",
+            "may",
+            "must"
+        ],
+        "acp_modify_presentattr": [
+            "class",
+            "description",
+            "may",
+            "must"
+        ],
+        "acp_modify_class":  [],
+        "acp_create_attr": [
+            "class",
+            "description",
+            "classname",
+            "may",
+            "must",
+            "uuid"
+        ],
+        "acp_create_class": [
+            "object", "classtype"
+        ]
+    }
+}"#;
+
+// 19 acp read/write
+pub static _UUID_IDM_ACP_ACP_MANAGER_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000019";
+pub static JSON_IDM_ACP_ACP_MANAGER_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_search",
+            "access_control_modify",
+            "access_control_create",
+            "access_control_delete"
+        ],
+        "name": ["idm_acp_acp_manager_priv"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000019"],
+        "description": ["Builtin IDM Control for access profiles management."],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000011\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Eq\": [\"class\",\"access_control_profile\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_search_attr": [
+            "name",
+            "class",
+            "description",
+            "acp_enable",
+            "acp_receiver",
+            "acp_targetscope",
+            "acp_search_attr",
+            "acp_modify_removedattr",
+            "acp_modify_presentattr",
+            "acp_modify_class",
+            "acp_create_class",
+            "acp_create_attr"
+        ],
+        "acp_modify_removedattr": [
+            "name",
+            "class",
+            "description",
+            "acp_enable",
+            "acp_receiver",
+            "acp_targetscope",
+            "acp_search_attr",
+            "acp_modify_removedattr",
+            "acp_modify_presentattr",
+            "acp_modify_class",
+            "acp_create_class",
+            "acp_create_attr"
+        ],
+        "acp_modify_presentattr": [
+            "name",
+            "class",
+            "description",
+            "acp_enable",
+            "acp_receiver",
+            "acp_targetscope",
+            "acp_search_attr",
+            "acp_modify_removedattr",
+            "acp_modify_presentattr",
+            "acp_modify_class",
+            "acp_create_class",
+            "acp_create_attr"
+        ],
+        "acp_modify_class":  [
+            "access_control_profile",
+            "access_control_search",
+            "access_control_modify",
+            "access_control_create",
+            "access_control_delete"
+        ],
+        "acp_create_attr": [
+            "name",
+            "class",
+            "description",
+            "acp_enable",
+            "acp_receiver",
+            "acp_targetscope",
+            "acp_search_attr",
+            "acp_modify_removedattr",
+            "acp_modify_presentattr",
+            "acp_modify_class",
+            "acp_create_class",
+            "acp_create_attr"
+        ],
+        "acp_create_class": [
+            "access_control_profile",
+            "access_control_search",
+            "access_control_modify",
+            "access_control_create",
+            "access_control_delete"
+        ]
+    }
+}"#;
+
+// 20 - anonymous / everyone schema read.
+
+
+// Anonymous should be the last opbject in the range here.
+pub static JSON_ANONYMOUS_V1: &'static str = r#"{
     "attrs": {
         "class": ["account", "object"],
         "name": ["anonymous"],
@@ -377,6 +1142,37 @@ pub static JSON_SCHEMA_ATTR_PRIMARY_CREDENTIAL: &'static str = r#"
     }
   }
 "#;
+pub static UUID_SCHEMA_ATTR_LEGALNAME: &'static str = "00000000-0000-0000-0000-ffff00000050";
+pub static JSON_SCHEMA_ATTR_LEGALNAME: &'static str = r#"{
+    "attrs": {
+      "class": [
+        "object",
+        "system",
+        "attributetype"
+      ],
+      "description": [
+        "The private and sensitive legal name of this person"
+      ],
+      "index": [
+        "EQUALITY"
+      ],
+      "unique": [
+        "false"
+      ],
+      "multivalue": [
+        "false"
+      ],
+      "attributename": [
+        "legalname"
+      ],
+      "syntax": [
+        "UTF8STRING"
+      ],
+      "uuid": [
+        "00000000-0000-0000-0000-ffff00000050"
+      ]
+    }
+}"#;
 
 pub static UUID_SCHEMA_CLASS_PERSON: &'static str = "00000000-0000-0000-0000-ffff00000044";
 pub static JSON_SCHEMA_CLASS_PERSON: &'static str = r#"
@@ -399,7 +1195,7 @@ pub static JSON_SCHEMA_CLASS_PERSON: &'static str = r#"
       ],
       "systemmay": [
         "mail",
-        "memberof"
+        "legalname"
       ],
       "systemmust": [
         "displayname",
@@ -446,10 +1242,6 @@ pub static JSON_SCHEMA_CLASS_GROUP: &'static str = r#"
 pub static UUID_SCHEMA_CLASS_ACCOUNT: &'static str = "00000000-0000-0000-0000-ffff00000046";
 pub static JSON_SCHEMA_CLASS_ACCOUNT: &'static str = r#"
   {
-    "valid": {
-      "uuid": "00000000-0000-0000-0000-ffff00000046"
-    },
-    "state": null,
     "attrs": {
       "class": [
         "object",
@@ -457,7 +1249,7 @@ pub static JSON_SCHEMA_CLASS_ACCOUNT: &'static str = r#"
         "classtype"
       ],
       "description": [
-        "Object representation of a person"
+        "Object representation of a account"
       ],
       "classname": [
         "account"

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -234,10 +234,14 @@ impl Entry<EntryInvalid, EntryNew> {
         es: &str,
         qs: &QueryServerWriteTransaction,
     ) -> Result<Self, OperationError> {
+        audit_log!(audit, "Parsing -> {}", es);
         // str -> Proto entry
         let pe: ProtoEntry = try_audit!(
             audit,
-            serde_json::from_str(es).map_err(|_| OperationError::SerdeJsonError)
+            serde_json::from_str(es).map_err(|e| {
+                audit_log!(audit, "SerdeJson Failure -> {:?}", e);
+                OperationError::SerdeJsonError
+            })
         );
         // now call from_proto_entry
         Self::from_proto_entry(audit, &pe, qs)

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -43,6 +43,7 @@ impl SchemaAttribute {
         value: &Entry<EntryValid, EntryCommitted>,
     ) -> Result<Self, OperationError> {
         // Convert entry to a schema attribute.
+        audit_log!(audit, "Converting -> {:?}", value);
         // class
         if !value.attribute_value_pres("class", &PVCLASS_ATTRIBUTETYPE) {
             audit_log!(audit, "class attribute type not present");


### PR DESCRIPTION
Implements #87 add default idm entries. This adds the fundamentals of the basic IDM layout. It contains the needed design document, and is designed such that the default admins while powerful, still have some limits upon them. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ x ] design document included (if relevant)
