### PR TITLE
Fix link to examples in ethics readme

### DIFF
--- a/ethics/README.md
+++ b/ethics/README.md
@@ -16,7 +16,7 @@ All people using this software should expect to have the right to:
 
 ## More?
 
-For more detailed examples, please see [EXAMPLES.md]
+For more detailed examples, please see [EXAMPLES.md](EXAMPLES.md)
 
 ## Questions?
 


### PR DESCRIPTION
I wish that syntax worked :/

- [-] cargo fmt has been run
- [-] cargo test has been run and passes
- [-] design document included (if relevant)
