### PR TITLE
WIP: Replace openssl with rustls+ring in the server

### DIFF
--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -50,7 +50,6 @@ time = "0.1"
 
 concread = "0.1"
 
-openssl = "0.10"
 rustls = "0.14.0"
 ring = "0.13.5"
 

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -52,6 +52,7 @@ concread = "0.1"
 
 openssl = "0.10"
 rustls = "0.14.0"
+ring = "0.13.5"
 
 rpassword = "0.4"
 num_cpus = "1.10"

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/server/main.rs"
 kanidm_proto = { path = "../kanidm_proto" }
 
 actix = "0.7"
-actix-web = { version = "0.7", features = ["ssl"] }
+actix-web = { version = "0.7", features = ["rust-tls"] }
 
 bytes = "0.4"
 log = "0.4"
@@ -51,6 +51,7 @@ time = "0.1"
 concread = "0.1"
 
 openssl = "0.10"
+rustls = "0.14.0"
 
 rpassword = "0.4"
 num_cpus = "1.10"

--- a/kanidmd/src/lib/be/dbvalue.rs
+++ b/kanidmd/src/lib/be/dbvalue.rs
@@ -2,7 +2,7 @@ use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum DbPasswordV1 {
-    PBKDF2(usize, Vec<u8>, Vec<u8>),
+    PBKDF2(u32, Vec<u8>, Vec<u8>),
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/kanidmd/src/lib/core.rs
+++ b/kanidmd/src/lib/core.rs
@@ -606,7 +606,7 @@ pub fn create_server_core(config: Configuration) {
     });
 
     let tls_aws_builder = match opt_tls_params {
-        Some(tls_params) => aws_builder.bind_ssl(config.address, tls_params),
+        Some(tls_params) => aws_builder.bind_rustls(config.address, tls_params),
         None => {
             warn!("Starting WITHOUT TLS parameters. This may cause authentication to fail!");
             aws_builder.bind(config.address)

--- a/kanidmd/src/lib/crypto.rs
+++ b/kanidmd/src/lib/crypto.rs
@@ -1,16 +1,43 @@
 use crate::config::Configuration;
-use openssl::error::ErrorStack;
-use openssl::ssl::{SslAcceptor, SslAcceptorBuilder, SslFiletype, SslMethod};
+use rustls::{internal::pemfile, NoClientAuth, PrivateKey, ServerConfig, TLSError};
+use std::fs::File;
+use std::io::{prelude::*, BufReader};
+use std::sync::Arc;
 
-pub fn setup_tls(config: &Configuration) -> Result<Option<SslAcceptorBuilder>, ErrorStack> {
+pub fn setup_tls(config: &Configuration) -> Result<Option<ServerConfig>, TLSError> {
     match &config.tls_config {
         Some(tls_config) => {
-            let mut ssl_builder = SslAcceptor::mozilla_modern(SslMethod::tls())?;
-            ssl_builder.set_ca_file(&tls_config.ca)?;
-            ssl_builder.set_private_key_file(&tls_config.key, SslFiletype::PEM)?;
-            ssl_builder.set_certificate_file(&tls_config.cert, SslFiletype::PEM)?;
-            ssl_builder.check_private_key()?;
-            Ok(Some(ssl_builder))
+            let mut cert_chain: Vec<rustls::Certificate> = Vec::new();
+
+            cert_chain.extend(
+                pemfile::certs(&mut BufReader::new(
+                    File::open(&tls_config.ca).expect("couldn't open ca"),
+                ))
+                .expect("couldn't read ca"),
+            );
+
+            cert_chain.extend(
+                pemfile::certs(&mut BufReader::new(
+                    File::open(&tls_config.cert).expect("couldn't open cert"),
+                ))
+                .expect("couldn't read cert"),
+            );
+
+            let mut keyfile =
+                BufReader::new(File::open(&tls_config.key).expect("couldn't open private key"));
+            let mut keys: Vec<PrivateKey> = pemfile::pkcs8_private_keys(&mut keyfile)
+                .or_else(|_| -> Result<_, ()> {
+                    keyfile.seek(std::io::SeekFrom::Start(0)).unwrap();
+                    Ok(pemfile::rsa_private_keys(&mut keyfile)?)
+                })
+                .expect("couldn't read private key");
+
+            let key = keys.pop().expect("no private keys in private key file");
+
+            let mut ssl_config = ServerConfig::new(Arc::new(NoClientAuth));
+            ssl_config.set_single_cert(cert_chain, key)?;
+
+            Ok(Some(ssl_config))
         }
         None => Ok(None),
     }


### PR DESCRIPTION
Ring is a gradual rewrite of parts of openssl in rust, and rustls is a pure-rust SSL library built on top of it.

Combined with #20, this would remove all native dependencies... almost.

Reqwest is depending on native-tls, so on unix platforms we'd still be using openssl, as a transitive dependency. Reqwest has a feature to depend on rustls, but we run into an issue:

Reqwest depends on rustls 0.16, but actix-web 0.7 depends on rustls 0.13. Because of the assembly code in ring, the versions cannot coexist. This means that for now, the server at least is completely openssl free, but the client (and the Cargo.lock) is not.

To unify the dependencies (and probably for other reasons...) we'd probably need to update to actix-web 1.0, a major breaking change (inexplicably, it no longer uses actix!)

- [x] cargo fmt has been run
- [x] cargo test has been run and passes
- [x] design document included (if relevant)
