### PR TITLE
Add tooling for accounts to self-set their password

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ let's encrypt, but if this is not possible, please use our insecure cert tool:
 You can now build and run the server with:
 
     cd kanidm
+    cargo run -- recover_account -D /tmp/kanidm.db -n admin
     cargo run -- server -D /tmp/kanidm.db -C ../insecure/ca.pem -c ../insecure/cert.pem -k ../insecure/key.pem --domain localhost --bindaddr 127.0.0.1:8080
 
 In a new terminal, you can now build and run the client tools with:
@@ -62,6 +63,7 @@ In a new terminal, you can now build and run the client tools with:
     cd kanidm_tools
     cargo run -- --help
     cargo run -- whoami -H https://localhost:8080 -D anonymous -C ../insecure/ca.pem
+    cargo run -- whoami -H https://localhost:8080 -D admin -C ../insecure/ca.pem
 
 ## Development and Testing
 

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -360,6 +360,19 @@ impl WhoamiResponse {
     }
 }
 
+// Simple string value provision.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SingleStringRequest {
+    pub value: String,
+}
+
+impl SingleStringRequest {
+    pub fn new(s: String) -> Self {
+        SingleStringRequest { value: s }
+    }
+}
+// Use OperationResponse here ...
+
 #[cfg(test)]
 mod tests {
     use crate::v1::Filter as ProtoFilter;

--- a/kanidm_tools/src/main.rs
+++ b/kanidm_tools/src/main.rs
@@ -48,11 +48,19 @@ struct SearchOpt {
 }
 
 #[derive(Debug, StructOpt)]
+enum AccountOpt {
+    #[structopt(name = "set_password")]
+    SetPassword(CommonOpt),
+}
+
+#[derive(Debug, StructOpt)]
 enum ClientOpt {
     #[structopt(name = "search")]
     Search(SearchOpt),
     #[structopt(name = "whoami")]
     Whoami(CommonOpt),
+    #[structopt(name = "account")]
+    Account(AccountOpt),
 }
 
 impl ClientOpt {
@@ -60,6 +68,9 @@ impl ClientOpt {
         match self {
             ClientOpt::Whoami(copt) => copt.debug,
             ClientOpt::Search(sopt) => sopt.commonopts.debug,
+            ClientOpt::Account(aopt) => match aopt {
+                AccountOpt::SetPassword(copt) => copt.debug,
+            },
         }
     }
 }
@@ -98,5 +109,14 @@ fn main() {
                 println!("{:?}", e);
             }
         }
+        ClientOpt::Account(aopt) => match aopt {
+            AccountOpt::SetPassword(copt) => {
+                let client = copt.to_client();
+
+                let password = rpassword::prompt_password_stderr("Enter new password: ").unwrap();
+
+                client.idm_account_set_password(password).unwrap();
+            }
+        },
     }
 }

--- a/kanidmd/src/lib/event.rs
+++ b/kanidmd/src/lib/event.rs
@@ -195,6 +195,13 @@ impl Event {
             _ => false,
         }
     }
+
+    pub fn get_uuid(&self) -> Option<&Uuid> {
+        match &self.origin {
+            EventOrigin::Internal => None,
+            EventOrigin::User(e) => Some(e.get_uuid()),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -3,6 +3,7 @@ use kanidm_proto::v1::OperationError;
 
 use kanidm_proto::v1::UserAuthToken;
 
+use crate::constants::UUID_ANONYMOUS;
 use crate::credential::Credential;
 use crate::idm::claim::Claim;
 use crate::idm::group::Group;
@@ -91,6 +92,10 @@ impl Account {
             groups: self.groups.iter().map(|g| g.into_proto()).collect(),
             claims: claims.iter().map(|c| c.into_proto()).collect(),
         })
+    }
+
+    pub fn is_anonymous(&self) -> bool {
+        self.uuid == *UUID_ANONYMOUS
     }
 
     pub(crate) fn gen_password_mod(

--- a/kanidmd/src/lib/idm/authsession.rs
+++ b/kanidmd/src/lib/idm/authsession.rs
@@ -1,5 +1,4 @@
 use crate::audit::AuditScope;
-use crate::constants::UUID_ANONYMOUS;
 use crate::idm::account::Account;
 use crate::idm::claim::Claim;
 use kanidm_proto::v1::OperationError;
@@ -159,7 +158,7 @@ impl AuthSession {
                 // We want the primary handler - this is where we make a decision
                 // based on the anonymous ... in theory this could be cleaner
                 // and interact with the account more?
-                if account.uuid == UUID_ANONYMOUS.clone() {
+                if account.is_anonymous() {
                     CredHandler::Anonymous
                 } else {
                     // Now we see if they have one ...

--- a/kanidmd/src/lib/idm/event.rs
+++ b/kanidmd/src/lib/idm/event.rs
@@ -1,5 +1,11 @@
+use crate::actors::v1::IdmAccountSetPasswordMessage;
+use crate::audit::AuditScope;
 use crate::event::Event;
+use crate::server::QueryServerWriteTransaction;
+
 use uuid::Uuid;
+
+use kanidm_proto::v1::OperationError;
 
 #[derive(Debug)]
 pub struct PasswordChangeEvent {
@@ -17,5 +23,21 @@ impl PasswordChangeEvent {
             cleartext: cleartext.to_string(),
             appid: appid.map(|v| v.to_string()),
         }
+    }
+
+    pub fn from_idm_account_set_password(
+        audit: &mut AuditScope,
+        qs: &QueryServerWriteTransaction,
+        msg: IdmAccountSetPasswordMessage,
+    ) -> Result<Self, OperationError> {
+        let e = Event::from_rw_uat(audit, qs, msg.uat)?;
+        let u = e.get_uuid().ok_or(OperationError::InvalidState)?.clone();
+
+        Ok(PasswordChangeEvent {
+            event: e,
+            target: u,
+            cleartext: msg.cleartext,
+            appid: None,
+        })
     }
 }

--- a/kanidmd/src/lib/idm/mod.rs
+++ b/kanidmd/src/lib/idm/mod.rs
@@ -1,10 +1,10 @@
 #[macro_use]
 mod macros;
-mod event;
 
 pub(crate) mod account;
 pub(crate) mod authsession;
 pub(crate) mod claim;
+pub(crate) mod event;
 pub(crate) mod group;
 pub(crate) mod server;
 // mod identity;


### PR DESCRIPTION
Partially Implements #6 - add ability for accounts to self set password. This is good for now, as I get closer to a trial radius deployment, but I think I'm finding the rest api probably needs a better plan at this point, as well as probably the way we do the proto and the communication needs some more thoughts too. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ - ] design document included (if relevant)
