### PR TITLE
Refactor client lib to expose msgs, and improve the messages in plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /insecure
 **/*.rs.bk
 test.db
+/vendor

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -18,6 +18,13 @@ pub enum SchemaError {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub enum PluginError {
+    AttrUnique(String),
+    Base(String),
+    ReferentialIntegrity(String),
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub enum OperationError {
     EmptyRequest,
     Backend,
@@ -25,20 +32,20 @@ pub enum OperationError {
     CorruptedEntry(u64),
     ConsistencyError(Vec<Result<(), ConsistencyError>>),
     SchemaViolation(SchemaError),
-    Plugin,
+    Plugin(PluginError),
     FilterGeneration,
     FilterUUIDResolution,
     InvalidAttributeName(String),
-    InvalidAttribute(&'static str),
+    InvalidAttribute(String),
     InvalidDBState,
     InvalidEntryID,
     InvalidRequestState,
     InvalidState,
     InvalidEntryState,
     InvalidUuid,
-    InvalidACPState(&'static str),
-    InvalidSchemaState(&'static str),
-    InvalidAccountState(&'static str),
+    InvalidACPState(String),
+    InvalidSchemaState(String),
+    InvalidAccountState(String),
     BackendEngine,
     SQLiteError, //(RusqliteError)
     FsError,
@@ -46,9 +53,10 @@ pub enum OperationError {
     SerdeCborError,
     AccessDenied,
     NotAuthenticated,
-    InvalidAuthState(&'static str),
+    InvalidAuthState(String),
     InvalidSessionState,
     SystemProtectedObject,
+    SystemProtectedAttribute,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -62,7 +70,7 @@ pub enum ConsistencyError {
     UuidNotUnique(String),
     RefintNotUpheld(u64),
     MemberOfInvalid(u64),
-    InvalidAttributeType(&'static str),
+    InvalidAttributeType(String),
     DuplicateUniqueAttribute(String),
 }
 

--- a/kanidmd/src/lib/access.rs
+++ b/kanidmd/src/lib/access.rs
@@ -58,7 +58,7 @@ impl AccessControlSearch {
         if !value.attribute_value_pres("class", &CLASS_ACS) {
             audit_log!(audit, "class access_control_search not present.");
             return Err(OperationError::InvalidACPState(
-                "Missing access_control_search",
+                "Missing access_control_search".to_string(),
             ));
         }
 
@@ -66,7 +66,9 @@ impl AccessControlSearch {
             audit,
             value
                 .get_ava_string("acp_search_attr")
-                .ok_or(OperationError::InvalidACPState("Missing acp_search_attr"))
+                .ok_or(OperationError::InvalidACPState(
+                    "Missing acp_search_attr".to_string()
+                ))
         );
 
         let acp = AccessControlProfile::try_from(audit, qs, value)?;
@@ -111,7 +113,7 @@ impl AccessControlDelete {
         if !value.attribute_value_pres("class", &CLASS_ACD) {
             audit_log!(audit, "class access_control_delete not present.");
             return Err(OperationError::InvalidACPState(
-                "Missing access_control_delete",
+                "Missing access_control_delete".to_string(),
             ));
         }
 
@@ -154,7 +156,7 @@ impl AccessControlCreate {
         if !value.attribute_value_pres("class", &CLASS_ACC) {
             audit_log!(audit, "class access_control_create not present.");
             return Err(OperationError::InvalidACPState(
-                "Missing access_control_create",
+                "Missing access_control_create".to_string(),
             ));
         }
 
@@ -212,7 +214,7 @@ impl AccessControlModify {
         if !value.attribute_value_pres("class", &CLASS_ACM) {
             audit_log!(audit, "class access_control_modify not present.");
             return Err(OperationError::InvalidACPState(
-                "Missing access_control_modify",
+                "Missing access_control_modify".to_string(),
             ));
         }
 
@@ -281,7 +283,7 @@ impl AccessControlProfile {
         if !value.attribute_value_pres("class", &CLASS_ACP) {
             audit_log!(audit, "class access_control_profile not present.");
             return Err(OperationError::InvalidACPState(
-                "Missing access_control_profile",
+                "Missing access_control_profile".to_string(),
             ));
         }
 
@@ -290,7 +292,7 @@ impl AccessControlProfile {
             audit,
             value
                 .get_ava_single_str("name")
-                .ok_or(OperationError::InvalidACPState("Missing name"))
+                .ok_or(OperationError::InvalidACPState("Missing name".to_string()))
         )
         .to_string();
         // copy uuid
@@ -298,16 +300,16 @@ impl AccessControlProfile {
         // receiver, and turn to real filter
         let receiver_f: ProtoFilter = try_audit!(
             audit,
-            value
-                .get_ava_single_protofilter("acp_receiver")
-                .ok_or(OperationError::InvalidACPState("Missing acp_receiver"))
+            value.get_ava_single_protofilter("acp_receiver").ok_or(
+                OperationError::InvalidACPState("Missing acp_receiver".to_string())
+            )
         );
         // targetscope, and turn to real filter
         let targetscope_f: ProtoFilter = try_audit!(
             audit,
-            value
-                .get_ava_single_protofilter("acp_targetscope")
-                .ok_or(OperationError::InvalidACPState("Missing acp_targetscope"))
+            value.get_ava_single_protofilter("acp_targetscope").ok_or(
+                OperationError::InvalidACPState("Missing acp_targetscope".to_string())
+            )
         );
 
         let receiver_i = try_audit!(audit, Filter::from_rw(audit, &receiver_f, qs));

--- a/kanidmd/src/lib/event.rs
+++ b/kanidmd/src/lib/event.rs
@@ -670,7 +670,7 @@ impl AuthEventStep {
             AuthStep::Init(name, appid) => {
                 if sid.is_some() {
                     Err(OperationError::InvalidAuthState(
-                        "session id present in init",
+                        "session id present in init".to_string(),
                     ))
                 } else {
                     Ok(AuthEventStep::Init(AuthEventStepInit {
@@ -685,7 +685,7 @@ impl AuthEventStep {
                     creds: creds,
                 })),
                 None => Err(OperationError::InvalidAuthState(
-                    "session id not present in cred",
+                    "session id not present in cred".to_string(),
                 )),
             },
         }

--- a/kanidmd/src/lib/idm/account.rs
+++ b/kanidmd/src/lib/idm/account.rs
@@ -42,7 +42,7 @@ impl Account {
         // Check the classes
         if !value.attribute_value_pres("class", &PVCLASS_ACCOUNT) {
             return Err(OperationError::InvalidAccountState(
-                "Missing class: account",
+                "Missing class: account".to_string(),
             ));
         }
 
@@ -51,11 +51,11 @@ impl Account {
             value
                 .get_ava_single_string("name")
                 .ok_or(OperationError::InvalidAccountState(
-                    "Missing attribute: name",
+                    "Missing attribute: name".to_string(),
                 ))?;
 
         let displayname = value.get_ava_single_string("displayname").ok_or(
-            OperationError::InvalidAccountState("Missing attribute: displayname"),
+            OperationError::InvalidAccountState("Missing attribute: displayname".to_string()),
         )?;
 
         let primary = value

--- a/kanidmd/src/lib/idm/authsession.rs
+++ b/kanidmd/src/lib/idm/authsession.rs
@@ -199,7 +199,7 @@ impl AuthSession {
     ) -> Result<AuthState, OperationError> {
         if self.finished {
             return Err(OperationError::InvalidAuthState(
-                "session already finalised!",
+                "session already finalised!".to_string(),
             ));
         }
 

--- a/kanidmd/src/lib/plugins/attrunique.rs
+++ b/kanidmd/src/lib/plugins/attrunique.rs
@@ -13,7 +13,7 @@ use crate::server::{
     QueryServerReadTransaction, QueryServerTransaction, QueryServerWriteTransaction,
 };
 use crate::value::PartialValue;
-use kanidm_proto::v1::{ConsistencyError, OperationError};
+use kanidm_proto::v1::{ConsistencyError, OperationError, PluginError};
 
 use std::collections::BTreeMap;
 
@@ -59,7 +59,9 @@ fn get_cand_attr_set<VALID, STATE>(
                         vr,
                         uuid
                     );
-                    return Err(OperationError::Plugin);
+                    return Err(OperationError::Plugin(PluginError::AttrUnique(
+                        "ava already exists".to_string(),
+                    )));
                 }
             }
         }
@@ -109,7 +111,9 @@ fn enforce_unique<STATE>(
 
     // If all okay, okay!
     if conflict_cand.len() > 0 {
-        return Err(OperationError::Plugin);
+        return Err(OperationError::Plugin(PluginError::AttrUnique(
+            "duplicate value detected".to_string(),
+        )));
     }
 
     Ok(())

--- a/kanidmd/src/lib/plugins/mod.rs
+++ b/kanidmd/src/lib/plugins/mod.rs
@@ -28,7 +28,7 @@ trait Plugin {
             "plugin {} has an unimplemented pre_create_transform!",
             Self::id()
         );
-        Err(OperationError::Plugin)
+        Err(OperationError::InvalidState)
     }
 
     fn pre_create(
@@ -39,7 +39,7 @@ trait Plugin {
         _ce: &CreateEvent,
     ) -> Result<(), OperationError> {
         debug!("plugin {} has an unimplemented pre_create!", Self::id());
-        Err(OperationError::Plugin)
+        Err(OperationError::InvalidState)
     }
 
     fn post_create(
@@ -50,7 +50,7 @@ trait Plugin {
         _ce: &CreateEvent,
     ) -> Result<(), OperationError> {
         debug!("plugin {} has an unimplemented post_create!", Self::id());
-        Err(OperationError::Plugin)
+        Err(OperationError::InvalidState)
     }
 
     fn pre_modify(
@@ -60,7 +60,7 @@ trait Plugin {
         _me: &ModifyEvent,
     ) -> Result<(), OperationError> {
         debug!("plugin {} has an unimplemented pre_modify!", Self::id());
-        Err(OperationError::Plugin)
+        Err(OperationError::InvalidState)
     }
 
     fn post_modify(
@@ -72,7 +72,7 @@ trait Plugin {
         _ce: &ModifyEvent,
     ) -> Result<(), OperationError> {
         debug!("plugin {} has an unimplemented post_modify!", Self::id());
-        Err(OperationError::Plugin)
+        Err(OperationError::InvalidState)
     }
 
     fn pre_delete(
@@ -82,7 +82,7 @@ trait Plugin {
         _de: &DeleteEvent,
     ) -> Result<(), OperationError> {
         debug!("plugin {} has an unimplemented pre_delete!", Self::id());
-        Err(OperationError::Plugin)
+        Err(OperationError::InvalidState)
     }
 
     fn post_delete(
@@ -93,7 +93,7 @@ trait Plugin {
         _ce: &DeleteEvent,
     ) -> Result<(), OperationError> {
         debug!("plugin {} has an unimplemented post_delete!", Self::id());
-        Err(OperationError::Plugin)
+        Err(OperationError::InvalidState)
     }
 
     fn verify(

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -47,39 +47,47 @@ impl SchemaAttribute {
         // class
         if !value.attribute_value_pres("class", &PVCLASS_ATTRIBUTETYPE) {
             audit_log!(audit, "class attribute type not present");
-            return Err(OperationError::InvalidSchemaState("missing attributetype"));
+            return Err(OperationError::InvalidSchemaState(
+                "missing attributetype".to_string(),
+            ));
         }
 
         // uuid
         let uuid = value.get_uuid().clone();
 
         // name
-        let name = try_audit!(
-            audit,
-            value
-                .get_ava_single_string("attributename")
-                .ok_or(OperationError::InvalidSchemaState("missing attributename"))
-        );
+        let name =
+            try_audit!(
+                audit,
+                value.get_ava_single_string("attributename").ok_or(
+                    OperationError::InvalidSchemaState("missing attributename".to_string())
+                )
+            );
         // description
-        let description = try_audit!(
-            audit,
-            value
-                .get_ava_single_string("description")
-                .ok_or(OperationError::InvalidSchemaState("missing description"))
-        );
+        let description =
+            try_audit!(
+                audit,
+                value.get_ava_single_string("description").ok_or(
+                    OperationError::InvalidSchemaState("missing description".to_string())
+                )
+            );
 
         // multivalue
         let multivalue = try_audit!(
             audit,
             value
                 .get_ava_single_bool("multivalue")
-                .ok_or(OperationError::InvalidSchemaState("missing multivalue"))
+                .ok_or(OperationError::InvalidSchemaState(
+                    "missing multivalue".to_string()
+                ))
         );
         let unique = try_audit!(
             audit,
             value
                 .get_ava_single_bool("unique")
-                .ok_or(OperationError::InvalidSchemaState("missing unique"))
+                .ok_or(OperationError::InvalidSchemaState(
+                    "missing unique".to_string()
+                ))
         );
         // index vec
         // even if empty, it SHOULD be present ... (is that value to put an empty set?)
@@ -92,7 +100,7 @@ impl SchemaAttribute {
                     .into_iter()
                     .map(|v: &IndexType| v.clone())
                     .collect()))
-                .map_err(|_| OperationError::InvalidSchemaState("Invalid index"))
+                .map_err(|_| OperationError::InvalidSchemaState("Invalid index".to_string()))
         );
         // syntax type
         let syntax = try_audit!(
@@ -100,7 +108,9 @@ impl SchemaAttribute {
             value
                 .get_ava_single_syntax("syntax")
                 .and_then(|s: &SyntaxType| Some(s.clone()))
-                .ok_or(OperationError::InvalidSchemaState("missing syntax"))
+                .ok_or(OperationError::InvalidSchemaState(
+                    "missing syntax".to_string()
+                ))
         );
 
         Ok(SchemaAttribute {
@@ -339,7 +349,9 @@ impl SchemaClass {
         // Convert entry to a schema class.
         if !value.attribute_value_pres("class", &PVCLASS_CLASSTYPE) {
             audit_log!(audit, "class classtype not present");
-            return Err(OperationError::InvalidSchemaState("missing classtype"));
+            return Err(OperationError::InvalidSchemaState(
+                "missing classtype".to_string(),
+            ));
         }
 
         // uuid
@@ -350,36 +362,41 @@ impl SchemaClass {
             audit,
             value
                 .get_ava_single_string("classname")
-                .ok_or(OperationError::InvalidSchemaState("missing classname"))
+                .ok_or(OperationError::InvalidSchemaState(
+                    "missing classname".to_string()
+                ))
         );
         // description
-        let description = try_audit!(
-            audit,
-            value
-                .get_ava_single_string("description")
-                .ok_or(OperationError::InvalidSchemaState("missing description"))
-        );
+        let description =
+            try_audit!(
+                audit,
+                value.get_ava_single_string("description").ok_or(
+                    OperationError::InvalidSchemaState("missing description".to_string())
+                )
+            );
 
         // These are all "optional" lists of strings.
         let systemmay =
             value
                 .get_ava_opt_string("systemmay")
                 .ok_or(OperationError::InvalidSchemaState(
-                    "Missing or invalid systemmay",
+                    "Missing or invalid systemmay".to_string(),
                 ))?;
         let systemmust =
             value
                 .get_ava_opt_string("systemmust")
                 .ok_or(OperationError::InvalidSchemaState(
-                    "Missing or invalid systemmust",
+                    "Missing or invalid systemmust".to_string(),
                 ))?;
         let may = value
             .get_ava_opt_string("may")
-            .ok_or(OperationError::InvalidSchemaState("Missing or invalid may"))?;
+            .ok_or(OperationError::InvalidSchemaState(
+                "Missing or invalid may".to_string(),
+            ))?;
         let must = value
             .get_ava_opt_string("must")
             .ok_or(OperationError::InvalidSchemaState(
-                "Missing or invalid must",
+                "Missing or invalid must".to_string(),
             ))?;
 
         Ok(SchemaClass {

--- a/kanidmd/src/lib/server.rs
+++ b/kanidmd/src/lib/server.rs
@@ -364,11 +364,11 @@ pub trait QueryServerTransaction {
                     SyntaxType::UTF8STRING => Ok(Value::new_utf8(value.clone())),
                     SyntaxType::UTF8STRING_INSENSITIVE => Ok(Value::new_iutf8s(value.as_str())),
                     SyntaxType::BOOLEAN => Value::new_bools(value.as_str())
-                        .ok_or(OperationError::InvalidAttribute("Invalid boolean syntax")),
+                        .ok_or(OperationError::InvalidAttribute("Invalid boolean syntax".to_string())),
                     SyntaxType::SYNTAX_ID => Value::new_syntaxs(value.as_str())
-                        .ok_or(OperationError::InvalidAttribute("Invalid Syntax syntax")),
+                        .ok_or(OperationError::InvalidAttribute("Invalid Syntax syntax".to_string())),
                     SyntaxType::INDEX_ID => Value::new_indexs(value.as_str())
-                        .ok_or(OperationError::InvalidAttribute("Invalid Index syntax")),
+                        .ok_or(OperationError::InvalidAttribute("Invalid Index syntax".to_string())),
                     SyntaxType::UUID => {
                         // It's a uuid - we do NOT check for existance, because that
                         // could be revealing or disclosing - it is up to acp to assert
@@ -386,7 +386,7 @@ pub trait QueryServerTransaction {
                                 Some(Value::new_uuid(un))
                             })
                             // I think this is unreachable due to how the .or_else works.
-                            .ok_or(OperationError::InvalidAttribute("Invalid UUID syntax"))
+                            .ok_or(OperationError::InvalidAttribute("Invalid UUID syntax".to_string()))
                     }
                     SyntaxType::REFERENCE_UUID => {
                         // See comments above.
@@ -398,11 +398,11 @@ pub trait QueryServerTransaction {
                                 Some(Value::new_refer(un))
                             })
                             // I think this is unreachable due to how the .or_else works.
-                            .ok_or(OperationError::InvalidAttribute("Invalid Reference syntax"))
+                            .ok_or(OperationError::InvalidAttribute("Invalid Reference syntax".to_string()))
                     }
                     SyntaxType::JSON_FILTER => Value::new_json_filter(value)
-                        .ok_or(OperationError::InvalidAttribute("Invalid Filter syntax")),
-                    SyntaxType::CREDENTIAL => Err(OperationError::InvalidAttribute("Credentials can not be supplied through modification - please use the IDM api")),
+                        .ok_or(OperationError::InvalidAttribute("Invalid Filter syntax".to_string())),
+                    SyntaxType::CREDENTIAL => Err(OperationError::InvalidAttribute("Credentials can not be supplied through modification - please use the IDM api".to_string())),
                 }
             }
             None => {
@@ -431,12 +431,15 @@ pub trait QueryServerTransaction {
                     SyntaxType::UTF8STRING_INSENSITIVE => {
                         Ok(PartialValue::new_iutf8s(value.as_str()))
                     }
-                    SyntaxType::BOOLEAN => PartialValue::new_bools(value.as_str())
-                        .ok_or(OperationError::InvalidAttribute("Invalid boolean syntax")),
-                    SyntaxType::SYNTAX_ID => PartialValue::new_syntaxs(value.as_str())
-                        .ok_or(OperationError::InvalidAttribute("Invalid Syntax syntax")),
-                    SyntaxType::INDEX_ID => PartialValue::new_indexs(value.as_str())
-                        .ok_or(OperationError::InvalidAttribute("Invalid Index syntax")),
+                    SyntaxType::BOOLEAN => PartialValue::new_bools(value.as_str()).ok_or(
+                        OperationError::InvalidAttribute("Invalid boolean syntax".to_string()),
+                    ),
+                    SyntaxType::SYNTAX_ID => PartialValue::new_syntaxs(value.as_str()).ok_or(
+                        OperationError::InvalidAttribute("Invalid Syntax syntax".to_string()),
+                    ),
+                    SyntaxType::INDEX_ID => PartialValue::new_indexs(value.as_str()).ok_or(
+                        OperationError::InvalidAttribute("Invalid Index syntax".to_string()),
+                    ),
                     SyntaxType::UUID => {
                         PartialValue::new_uuids(value.as_str())
                             .or_else(|| {
@@ -450,7 +453,9 @@ pub trait QueryServerTransaction {
                                 Some(PartialValue::new_uuid(un))
                             })
                             // I think this is unreachable due to how the .or_else works.
-                            .ok_or(OperationError::InvalidAttribute("Invalid UUID syntax"))
+                            .ok_or(OperationError::InvalidAttribute(
+                                "Invalid UUID syntax".to_string(),
+                            ))
                     }
                     SyntaxType::REFERENCE_UUID => {
                         // See comments above.
@@ -462,10 +467,13 @@ pub trait QueryServerTransaction {
                                 Some(PartialValue::new_refer(un))
                             })
                             // I think this is unreachable due to how the .or_else works.
-                            .ok_or(OperationError::InvalidAttribute("Invalid Reference syntax"))
+                            .ok_or(OperationError::InvalidAttribute(
+                                "Invalid Reference syntax".to_string(),
+                            ))
                     }
-                    SyntaxType::JSON_FILTER => PartialValue::new_json_filter(value)
-                        .ok_or(OperationError::InvalidAttribute("Invalid Filter syntax")),
+                    SyntaxType::JSON_FILTER => PartialValue::new_json_filter(value).ok_or(
+                        OperationError::InvalidAttribute("Invalid Filter syntax".to_string()),
+                    ),
                     SyntaxType::CREDENTIAL => Ok(PartialValue::new_credential_tag(value.as_str())),
                 }
             }


### PR DESCRIPTION
Implements #100. This refactors our error types to be deserialiseable, and exposes these through the clienterror type with the status codes. There is probably still a lot of improvements here to be made, but they'll be shaken out as the client libs develop I think and we start to see what errors should be exposed. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ - ] design document included (if relevant)
