### PR TITLE
126 ssh key features

### DIFF
--- a/insecure_generate_tls.sh
+++ b/insecure_generate_tls.sh
@@ -2,9 +2,9 @@
 
 cat > ./altnames.cnf << DEVEOF
 [req]
-req_extensions = v3_req
 nsComment = "Certificate"
 distinguished_name  = req_distinguished_name
+req_extensions = v3_req
 
 [ req_distinguished_name ]
 
@@ -38,15 +38,16 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 subjectAltName = @alt_names
 
 [alt_names]
-DNS.1 = 127.0.0.1
+DNS.1 = localhost
+IP.1 = 127.0.0.1
 
 DEVEOF
 
 # Make the ca
 openssl req -x509 -new -newkey rsa:2048 -keyout cakey.pem -out ca.pem -days 31 -subj "/C=AU/ST=Queensland/L=Brisbane/O=INSECURE/CN=insecure.ca.localhost" -nodes
 openssl genrsa -out key.pem 2048
-openssl req -key key.pem -out cert.csr -days 31 -config altnames.cnf -new
-openssl x509 -req -days 31 -in cert.csr -CA ca.pem -CAkey cakey.pem -CAcreateserial -out cert.pem
+openssl req -key key.pem -out cert.csr -days 31 -config altnames.cnf -new -extensions v3_req
+openssl x509 -req -days 31 -in cert.csr -CA ca.pem -CAkey cakey.pem -CAcreateserial -out cert.pem -extfile altnames.cnf -extensions v3_req
 
 echo use ca.pem, cert.pem, and key.pem
 

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -435,11 +435,13 @@ impl KanidmClient {
         self.perform_post_request(format!("/v1/account/{}/_ssh_pubkeys", id).as_str(), sk)
     }
 
+    /*
     pub fn idm_account_rename_ssh_pubkey(&self, id: &str, oldtag: &str, newtag: &str) -> Result<(), ClientError> {
         self.perform_put_request(format!("/v1/account/{}/_ssh_pubkeys/{}", id, oldtag).as_str(), newtag.to_string())
     }
+    */
 
-    pub fn idm_account_get_ssh_pubkey(&self, id: &str, tag: &str) -> Result<String, ClientError> {
+    pub fn idm_account_get_ssh_pubkey(&self, id: &str, tag: &str) -> Result<Option<String>, ClientError> {
         self.perform_get_request(format!("/v1/account/{}/_ssh_pubkeys/{}", id, tag).as_str())
     }
 

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -69,9 +69,9 @@ impl KanidmClient {
 
     fn build_reqwest(ca: &Option<reqwest::Certificate>) -> Result<reqwest::Client, reqwest::Error> {
         let client_builder = reqwest::Client::builder()
-            .cookie_store(true)
+            .cookie_store(true);
             // .danger_accept_invalid_hostnames(true)
-            .danger_accept_invalid_certs(true);
+            // .danger_accept_invalid_certs(true);
 
         let client_builder = match ca {
             Some(cert) => client_builder.add_root_certificate(cert.clone()),

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -426,6 +426,28 @@ impl KanidmClient {
         self.perform_get_request(format!("/v1/account/{}/_radius/_token", id).as_str())
     }
 
+    pub fn idm_account_get_ssh_pubkeys(&self, id: &str) -> Result<Vec<String>, ClientError> {
+        self.perform_get_request(format!("/v1/account/{}/_ssh_pubkeys", id).as_str())
+    }
+
+    pub fn idm_account_post_ssh_pubkey(&self, id: &str, tag: &str, pubkey: &str) -> Result<(), ClientError> {
+        let sk = (tag.to_string(), pubkey.to_string());
+        self.perform_post_request(format!("/v1/account/{}/_ssh_pubkeys", id).as_str(), sk)
+    }
+
+    pub fn idm_account_rename_ssh_pubkey(&self, id: &str, oldtag: &str, newtag: &str) -> Result<(), ClientError> {
+        self.perform_put_request(format!("/v1/account/{}/_ssh_pubkeys/{}", id, oldtag).as_str(), newtag.to_string())
+    }
+
+    pub fn idm_account_get_ssh_pubkey(&self, id: &str, tag: &str) -> Result<String, ClientError> {
+        self.perform_get_request(format!("/v1/account/{}/_ssh_pubkeys/{}", id, tag).as_str())
+    }
+
+    pub fn idm_account_delete_ssh_pubkey(&self, id: &str, tag: &str) -> Result<(), ClientError> {
+        self.perform_delete_request(format!("/v1/account/{}/_ssh_pubkeys/{}", id, tag).as_str())
+    }
+
+
     // ==== schema
     pub fn idm_schema_list(&self) -> Result<Vec<Entry>, ClientError> {
         self.perform_get_request("/v1/schema")

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -68,7 +68,10 @@ impl KanidmClient {
     }
 
     fn build_reqwest(ca: &Option<reqwest::Certificate>) -> Result<reqwest::Client, reqwest::Error> {
-        let client_builder = reqwest::Client::builder().cookie_store(true);
+        let client_builder = reqwest::Client::builder()
+            .cookie_store(true)
+            // .danger_accept_invalid_hostnames(true)
+            .danger_accept_invalid_certs(true);
 
         let client_builder = match ca {
             Some(cert) => client_builder.add_root_certificate(cert.clone()),
@@ -430,7 +433,12 @@ impl KanidmClient {
         self.perform_get_request(format!("/v1/account/{}/_ssh_pubkeys", id).as_str())
     }
 
-    pub fn idm_account_post_ssh_pubkey(&self, id: &str, tag: &str, pubkey: &str) -> Result<(), ClientError> {
+    pub fn idm_account_post_ssh_pubkey(
+        &self,
+        id: &str,
+        tag: &str,
+        pubkey: &str,
+    ) -> Result<(), ClientError> {
         let sk = (tag.to_string(), pubkey.to_string());
         self.perform_post_request(format!("/v1/account/{}/_ssh_pubkeys", id).as_str(), sk)
     }
@@ -441,14 +449,17 @@ impl KanidmClient {
     }
     */
 
-    pub fn idm_account_get_ssh_pubkey(&self, id: &str, tag: &str) -> Result<Option<String>, ClientError> {
+    pub fn idm_account_get_ssh_pubkey(
+        &self,
+        id: &str,
+        tag: &str,
+    ) -> Result<Option<String>, ClientError> {
         self.perform_get_request(format!("/v1/account/{}/_ssh_pubkeys/{}", id, tag).as_str())
     }
 
     pub fn idm_account_delete_ssh_pubkey(&self, id: &str, tag: &str) -> Result<(), ClientError> {
         self.perform_delete_request(format!("/v1/account/{}/_ssh_pubkeys/{}", id, tag).as_str())
     }
-
 
     // ==== schema
     pub fn idm_schema_list(&self) -> Result<Vec<Entry>, ClientError> {

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -472,6 +472,45 @@ fn test_server_rest_account_lifecycle() {
     });
 }
 
+#[test]
+fn test_server_rest_sshkey_lifecycle() {
+    run_test(|rsclient: KanidmClient| {
+        let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
+        assert!(res.is_ok());
+
+        // Get the keys, should be empty vec.
+        let sk1 = rsclient
+            .idm_account_get_ssh_pubkeys("admin").unwrap();
+        assert!(sk1.len() == 0);
+
+        // idm_account_get_ssh_pubkeys
+        // idm_account_post_ssh_pubkey
+        // idm_account_rename_ssh_pubkey
+        // idm_account_get_ssh_pubkey
+        // idm_account_delete_ssh_pubkey
+
+        // Post an invalid key (should error)
+
+        // Post a valid key
+
+        // Get, should have the key
+        // Post a valid key
+
+        // Get, should have both keys.
+
+        // Delete a key (by tag)
+
+        // Get, should have remaining key.
+
+        // Put and rename
+
+        // get based on the old tag (empty)
+
+        // get new tag
+
+    });
+}
+
 // Test the self version of the radius path.
 
 // Test hitting all auth-required endpoints and assert they give unauthorized.

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -479,8 +479,7 @@ fn test_server_rest_sshkey_lifecycle() {
         assert!(res.is_ok());
 
         // Get the keys, should be empty vec.
-        let sk1 = rsclient
-            .idm_account_get_ssh_pubkeys("admin").unwrap();
+        let sk1 = rsclient.idm_account_get_ssh_pubkeys("admin").unwrap();
         assert!(sk1.len() == 0);
 
         // idm_account_get_ssh_pubkeys
@@ -489,8 +488,7 @@ fn test_server_rest_sshkey_lifecycle() {
         // idm_account_delete_ssh_pubkey
 
         // Post an invalid key (should error)
-        let r1 = rsclient
-            .idm_account_post_ssh_pubkey("admin", "inv", "invalid key");
+        let r1 = rsclient.idm_account_post_ssh_pubkey("admin", "inv", "invalid key");
         assert!(r1.is_err());
 
         // Post a valid key
@@ -500,8 +498,7 @@ fn test_server_rest_sshkey_lifecycle() {
         assert!(r2.is_ok());
 
         // Get, should have the key
-        let sk2 = rsclient
-            .idm_account_get_ssh_pubkeys("admin").unwrap();
+        let sk2 = rsclient.idm_account_get_ssh_pubkeys("admin").unwrap();
         assert!(sk2.len() == 1);
 
         // Post a valid key
@@ -510,23 +507,19 @@ fn test_server_rest_sshkey_lifecycle() {
         assert!(r3.is_ok());
 
         // Get, should have both keys.
-        let sk3 = rsclient
-            .idm_account_get_ssh_pubkeys("admin").unwrap();
+        let sk3 = rsclient.idm_account_get_ssh_pubkeys("admin").unwrap();
         assert!(sk3.len() == 2);
 
         // Delete a key (by tag)
-        let r4 = rsclient
-            .idm_account_delete_ssh_pubkey("admin", "k1");
+        let r4 = rsclient.idm_account_delete_ssh_pubkey("admin", "k1");
         assert!(r4.is_ok());
 
         // Get, should have remaining key.
-        let sk4 = rsclient
-            .idm_account_get_ssh_pubkeys("admin").unwrap();
+        let sk4 = rsclient.idm_account_get_ssh_pubkeys("admin").unwrap();
         assert!(sk4.len() == 1);
 
         // get by tag
-        let skn = rsclient
-            .idm_account_get_ssh_pubkey("admin", "k2");
+        let skn = rsclient.idm_account_get_ssh_pubkey("admin", "k2");
         assert!(skn.is_ok());
         assert!(skn.unwrap() == Some("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBx4TpJYQjd0YI5lQIHqblIsCIK5NKVFURYS/eM3o6/Z william@amethyst".to_string()));
     });

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -485,29 +485,50 @@ fn test_server_rest_sshkey_lifecycle() {
 
         // idm_account_get_ssh_pubkeys
         // idm_account_post_ssh_pubkey
-        // idm_account_rename_ssh_pubkey
         // idm_account_get_ssh_pubkey
         // idm_account_delete_ssh_pubkey
 
         // Post an invalid key (should error)
+        let r1 = rsclient
+            .idm_account_post_ssh_pubkey("admin", "inv", "invalid key");
+        assert!(r1.is_err());
 
         // Post a valid key
+        let r2 = rsclient
+            .idm_account_post_ssh_pubkey("admin", "k1", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAeGW1P6Pc2rPq0XqbRaDKBcXZUPRklo0L1EyR30CwoP william@amethyst");
+        println!("{:?}", r2);
+        assert!(r2.is_ok());
 
         // Get, should have the key
+        let sk2 = rsclient
+            .idm_account_get_ssh_pubkeys("admin").unwrap();
+        assert!(sk2.len() == 1);
+
         // Post a valid key
+        let r3 = rsclient
+            .idm_account_post_ssh_pubkey("admin", "k2", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBx4TpJYQjd0YI5lQIHqblIsCIK5NKVFURYS/eM3o6/Z william@amethyst");
+        assert!(r3.is_ok());
 
         // Get, should have both keys.
+        let sk3 = rsclient
+            .idm_account_get_ssh_pubkeys("admin").unwrap();
+        assert!(sk3.len() == 2);
 
         // Delete a key (by tag)
+        let r4 = rsclient
+            .idm_account_delete_ssh_pubkey("admin", "k1");
+        assert!(r4.is_ok());
 
         // Get, should have remaining key.
+        let sk4 = rsclient
+            .idm_account_get_ssh_pubkeys("admin").unwrap();
+        assert!(sk4.len() == 1);
 
-        // Put and rename
-
-        // get based on the old tag (empty)
-
-        // get new tag
-
+        // get by tag
+        let skn = rsclient
+            .idm_account_get_ssh_pubkey("admin", "k2");
+        assert!(skn.is_ok());
+        assert!(skn.unwrap() == Some("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBx4TpJYQjd0YI5lQIHqblIsCIK5NKVFURYS/eM3o6/Z william@amethyst".to_string()));
     });
 }
 

--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -20,6 +20,7 @@ rpassword = "0.4"
 structopt = { version = "0.2", default-features = false }
 log = "0.4"
 env_logger = "0.6"
+toml = "0.5"
 serde = "1.0"
 serde_json = "1.0"
 

--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -3,10 +3,15 @@ name = "kanidm_tools"
 version = "0.1.0"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2018"
+default-run = "kanidm"
 
 [[bin]]
 name = "kanidm"
 path = "src/main.rs"
+
+[[bin]]
+name = "kanidm_ssh_authorizedkeys"
+path = "src/ssh_authorizedkeys.rs"
 
 [dependencies]
 kanidm_client = { path = "../kanidm_client" }

--- a/kanidm_tools/src/ssh_authorizedkeys.rs
+++ b/kanidm_tools/src/ssh_authorizedkeys.rs
@@ -1,0 +1,56 @@
+extern crate structopt;
+use kanidm_client::KanidmClient;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+extern crate env_logger;
+#[macro_use]
+extern crate log;
+
+#[derive(Debug, StructOpt)]
+struct ClientOpt {
+    #[structopt(short = "d", long = "debug")]
+    debug: bool,
+    #[structopt(short = "H", long = "url")]
+    addr: String,
+    #[structopt(short = "D", long = "name")]
+    username: String,
+    #[structopt(parse(from_os_str), short = "C", long = "ca")]
+    ca_path: Option<PathBuf>,
+    #[structopt()]
+    account_id: String,
+}
+
+// For now we lift a few things from the main.rs to use.
+fn main() {
+    let opt = ClientOpt::from_args();
+    if opt.debug {
+        ::std::env::set_var("RUST_LOG", "kanidm=debug,kanidm_client=debug");
+    } else {
+        ::std::env::set_var("RUST_LOG", "kanidm=info,kanidm_client=info");
+    }
+    env_logger::init();
+
+    let ca_path: Option<&str> = opt.ca_path.as_ref().map(|p| p.to_str().unwrap());
+    let client = KanidmClient::new(opt.addr.as_str(), ca_path);
+
+    let r = if opt.username == "anonymous" {
+        client.auth_anonymous()
+    } else {
+        let password = rpassword::prompt_password_stderr("Enter password: ").unwrap();
+        client.auth_simple_password(opt.username.as_str(), password.as_str())
+    };
+
+    if r.is_err() {
+        eprintln!("Error during authentication phase: {:?}", r);
+        std::process::exit(1);
+    }
+
+    let pkeys = client
+        .idm_account_get_ssh_pubkeys(opt.account_id.as_str())
+        .unwrap();
+
+    for pkey in pkeys {
+        println!("{}", pkey)
+    }
+}

--- a/kanidm_tools/src/ssh_authorizedkeys.rs
+++ b/kanidm_tools/src/ssh_authorizedkeys.rs
@@ -22,6 +22,9 @@ struct ClientOpt {
 }
 
 // For now we lift a few things from the main.rs to use.
+//
+// usage: AuthorizedKeysCommand /usr/sbin/kanidm_ssh_authorizedkeys %u -H URL -D anonymous -C /etc/kanidm/ca.pem
+//
 fn main() {
     let opt = ClientOpt::from_args();
     if opt.debug {

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -51,6 +51,7 @@ time = "0.1"
 concread = "0.1"
 
 openssl = "0.10"
+sshkeys = "0.1"
 
 rpassword = "0.4"
 num_cpus = "1.10"

--- a/kanidmd/Dockerfile
+++ b/kanidmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/tumbleweed:latest
+FROM opensuse/tumbleweed:latest AS builder
 MAINTAINER william@blackhats.net.au
 
 COPY . /home/kanidm/
@@ -12,7 +12,8 @@ FROM opensuse/tumbleweed:latest
 
 EXPOSE 8080
 WORKDIR /
-COPY --from=0 /home/kanidm/target/release/kanidmd /sbin/
+COPY --from=builder /home/kanidm/target/release/kanidmd /sbin/
+RUN zypper install -y sqlite3 openssl
 
 VOLUME /data
 

--- a/kanidmd/src/lib/actors/v1_read.rs
+++ b/kanidmd/src/lib/actors/v1_read.rs
@@ -103,6 +103,15 @@ impl Message for InternalRadiusTokenReadMessage {
     type Result = Result<RadiusAuthToken, OperationError>;
 }
 
+pub struct InternalSshKeyReadMessage {
+    pub uat: Option<UserAuthToken>,
+    pub uuid_or_name: String,
+}
+
+impl Message for InternalSshKeyReadMessage {
+    type Result = Result<Vec<String>, OperationError>;
+}
+
 // ===========================================================
 
 pub struct QueryServerReadV1 {
@@ -403,6 +412,67 @@ impl Handler<InternalRadiusTokenReadMessage> for QueryServerReadV1 {
             audit_log!(audit, "Begin event {:?}", rate);
 
             idm_read.get_radiusauthtoken(&mut audit, &rate)
+        });
+        self.log.do_send(audit);
+        res
+    }
+}
+
+impl Handler<InternalSshKeyReadMessage> for QueryServerReadV1 {
+    type Result = Result<Vec<String>, OperationError>;
+
+    fn handle(
+        &mut self,
+        msg: InternalSshKeyReadMessage,
+        _: &mut Self::Context,
+    ) -> Self::Result {
+        let mut audit = AuditScope::new("internal_sshkey_read_message");
+        let res = audit_segment!(&mut audit, || {
+            let qs_read = self.qs.read();
+
+            let target_uuid = match Uuid::parse_str(msg.uuid_or_name.as_str()) {
+                Ok(u) => u,
+                Err(_) => qs_read
+                    .name_to_uuid(&mut audit, msg.uuid_or_name.as_str())
+                    .map_err(|e| {
+                        audit_log!(&mut audit, "Error resolving id to target");
+                        e
+                    })?,
+            };
+
+            // Make an event from the request
+            let srch = match SearchEvent::from_target_uuid_request(
+                &mut audit,
+                msg.uat,
+                target_uuid,
+                &qs_read,
+            ) {
+                Ok(s) => s,
+                Err(e) => {
+                    audit_log!(audit, "Failed to begin search: {:?}", e);
+                    return Err(e);
+                }
+            };
+
+            audit_log!(audit, "Begin event {:?}", srch);
+
+            match qs_read.search_ext(&mut audit, &srch) {
+                Ok(mut entries) => {
+                    let r = entries
+                        .pop()
+                        // get the first entry
+                        .map(|e| {
+                            // From the entry, turn it into the value
+                            e.get_ava_ssh_pubkeys("ssh_publickey")
+                        })
+                        .unwrap_or_else(|| {
+                            // No matching entry? Return none.
+                            Vec::new()
+                        });
+                    Ok(r)
+                }
+                Err(e) => Err(e),
+            }
         });
         self.log.do_send(audit);
         res

--- a/kanidmd/src/lib/actors/v1_write.rs
+++ b/kanidmd/src/lib/actors/v1_write.rs
@@ -6,6 +6,8 @@ use crate::event::{
     CreateEvent, DeleteEvent, ModifyEvent, PurgeRecycledEvent, PurgeTombstoneEvent,
 };
 use crate::idm::event::{GeneratePasswordEvent, PasswordChangeEvent, RegenerateRadiusSecretEvent};
+use crate::modify::{ModifyList, ModifyInvalid};
+use crate::value::Value;
 use kanidm_proto::v1::OperationError;
 
 use crate::filter::{Filter, FilterInvalid};
@@ -147,6 +149,18 @@ impl Message for InternalRegenerateRadiusMessage {
     type Result = Result<String, OperationError>;
 }
 
+pub struct InternalSshKeyCreateMessage {
+    pub uat: Option<UserAuthToken>,
+    pub uuid_or_name: String,
+    pub tag: String,
+    pub key: String,
+    pub filter: Filter<FilterInvalid>,
+}
+
+impl Message for InternalSshKeyCreateMessage {
+    type Result = Result<(), OperationError>;
+}
+
 /// Indicate that we want to purge an attribute from the entry - this is generally
 /// in response to a DELETE http method.
 pub struct PurgeAttributeMessage {
@@ -157,6 +171,19 @@ pub struct PurgeAttributeMessage {
 }
 
 impl Message for PurgeAttributeMessage {
+    type Result = Result<(), OperationError>;
+}
+
+/// Delete a single attribute-value pair from the entry.
+pub struct RemoveAttributeValueMessage {
+    pub uat: Option<UserAuthToken>,
+    pub uuid_or_name: String,
+    pub attr: String,
+    pub value: String,
+    pub filter: Filter<FilterInvalid>,
+}
+
+impl Message for RemoveAttributeValueMessage {
     type Result = Result<(), OperationError>;
 }
 
@@ -242,6 +269,42 @@ impl QueryServerWriteV1 {
 
         let mdf =
             match ModifyEvent::from_parts(audit, uat, target_uuid, proto_ml, filter, &qs_write) {
+                Ok(m) => m,
+                Err(e) => {
+                    audit_log!(audit, "Failed to begin modify: {:?}", e);
+                    return Err(e);
+                }
+            };
+
+        audit_log!(audit, "Begin modify event {:?}", mdf);
+
+        qs_write
+            .modify(audit, &mdf)
+            .and_then(|_| qs_write.commit(audit).map(|_| ()))
+    }
+
+    fn modify_from_internal_parts(
+        &mut self,
+        audit: &mut AuditScope,
+        uat: Option<UserAuthToken>,
+        uuid_or_name: String,
+        ml: ModifyList<ModifyInvalid>,
+        filter: Filter<FilterInvalid>,
+    ) -> Result<(), OperationError> {
+        let mut qs_write = self.qs.write();
+
+        let target_uuid = match Uuid::parse_str(uuid_or_name.as_str()) {
+            Ok(u) => u,
+            Err(_) => qs_write
+                .name_to_uuid(audit, uuid_or_name.as_str())
+                .map_err(|e| {
+                    audit_log!(audit, "Error resolving id to target");
+                    e
+                })?,
+        };
+
+        let mdf =
+            match ModifyEvent::from_internal_parts(audit, uat, target_uuid, ml, filter, &qs_write) {
                 Ok(m) => m,
                 Err(e) => {
                     audit_log!(audit, "Failed to begin modify: {:?}", e);
@@ -559,6 +622,53 @@ impl Handler<PurgeAttributeMessage> for QueryServerWriteV1 {
     }
 }
 
+impl Handler<RemoveAttributeValueMessage> for QueryServerWriteV1 {
+    type Result = Result<(), OperationError>;
+
+    fn handle(&mut self, msg: RemoveAttributeValueMessage, _: &mut Self::Context) -> Self::Result {
+        let mut audit = AuditScope::new("remove_attribute_value");
+        let res = audit_segment!(&mut audit, || {
+            let mut qs_write = self.qs.write();
+            let target_uuid = match Uuid::parse_str(msg.uuid_or_name.as_str()) {
+                Ok(u) => u,
+                Err(_) => qs_write
+                    .name_to_uuid(&mut audit, msg.uuid_or_name.as_str())
+                    .map_err(|e| {
+                        audit_log!(&mut audit, "Error resolving id to target");
+                        e
+                    })?,
+            };
+
+            let proto_ml = ProtoModifyList::new_list(vec![
+                ProtoModify::Removed(msg.attr, msg.value)
+            ]);
+
+            let mdf = match ModifyEvent::from_parts(
+                &mut audit,
+                msg.uat,
+                target_uuid,
+                proto_ml,
+                msg.filter,
+                &qs_write,
+            ) {
+                Ok(m) => m,
+                Err(e) => {
+                    audit_log!(audit, "Failed to begin modify: {:?}", e);
+                    return Err(e);
+                }
+            };
+
+            audit_log!(audit, "Begin modify event {:?}", mdf);
+
+            qs_write
+                .modify(&mut audit, &mdf)
+                .and_then(|_| qs_write.commit(&mut audit).map(|_| ()))
+        });
+        self.log.do_send(audit);
+        res
+    }
+}
+
 impl Handler<AppendAttributeMessage> for QueryServerWriteV1 {
     type Result = Result<(), OperationError>;
 
@@ -612,6 +722,30 @@ impl Handler<SetAttributeMessage> for QueryServerWriteV1 {
                     .collect(),
             );
             self.modify_from_parts(&mut audit, uat, uuid_or_name, proto_ml, filter)
+        });
+        self.log.do_send(audit);
+        res
+    }
+}
+
+impl Handler<InternalSshKeyCreateMessage> for QueryServerWriteV1 {
+    type Result = Result<(), OperationError>;
+
+    fn handle(&mut self, msg: InternalSshKeyCreateMessage, _: &mut Self::Context) -> Self::Result {
+        let mut audit = AuditScope::new("internal_sshkey_create");
+        let res = audit_segment!(&mut audit, || {
+            let InternalSshKeyCreateMessage {
+                uat,
+                uuid_or_name,
+                tag, key, filter
+            } = msg;
+
+            // Because this is from internal, we can generate a real modlist, rather
+            // than relying on the proto ones.
+            let ml = ModifyList::new_append("ssh_publickey",
+                Value::new_sshkey(tag, key));
+
+            self.modify_from_internal_parts(&mut audit, uat, uuid_or_name, ml, filter)
         });
         self.log.do_send(audit);
         res

--- a/kanidmd/src/lib/constants.rs
+++ b/kanidmd/src/lib/constants.rs
@@ -498,7 +498,9 @@ pub static JSON_IDM_ALL_ACP_READ_V1: &'static str = r#"{
             "displayname",
             "class",
             "memberof",
-            "member"
+            "member",
+            "uuid",
+            "ssh_publickey"
         ]
     }
 }"#;

--- a/kanidmd/src/lib/core.rs
+++ b/kanidmd/src/lib/core.rs
@@ -17,13 +17,14 @@ use crate::config::Configuration;
 use crate::actors::v1_read::QueryServerReadV1;
 use crate::actors::v1_read::{
     AuthMessage, InternalRadiusReadMessage, InternalRadiusTokenReadMessage, InternalSearchMessage,
-    SearchMessage, WhoamiMessage, InternalSshKeyReadMessage,
+    SearchMessage, WhoamiMessage, InternalSshKeyReadMessage, InternalSshKeyTagReadMessage
 };
 use crate::actors::v1_write::QueryServerWriteV1;
 use crate::actors::v1_write::{
     AppendAttributeMessage, CreateMessage, DeleteMessage, IdmAccountSetPasswordMessage,
     InternalCredentialSetMessage, InternalDeleteMessage, InternalRegenerateRadiusMessage,
-    ModifyMessage, PurgeAttributeMessage, SetAttributeMessage,
+    ModifyMessage, PurgeAttributeMessage, SetAttributeMessage, RemoveAttributeValueMessage,
+    InternalSshKeyCreateMessage
 };
 use crate::async_log;
 use crate::audit::AuditScope;
@@ -720,6 +721,100 @@ fn account_get_id_ssh_pubkeys(
     let res = state.qe_r.send(obj).from_err().and_then(|res| match res {
         Ok(event_result) => {
             // Only send back the first result, or None
+            Ok(HttpResponse::Ok().json(event_result))
+        }
+        Err(e) => Ok(operation_error_to_response(e)),
+    });
+
+    Box::new(res)
+}
+
+fn account_post_id_ssh_pubkey(
+    (path, req, state): (Path<String>, HttpRequest<AppState>, State<AppState>),
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let max_size = state.max_size;
+    let uat = get_current_user(&req);
+    let id = path.into_inner();
+
+    req.payload()
+        .from_err()
+        .fold(BytesMut::new(), move |mut body, chunk| {
+            // limit max size of in-memory payload
+            if (body.len() + chunk.len()) > max_size {
+                Err(error::ErrorBadRequest("overflow"))
+            } else {
+                body.extend_from_slice(&chunk);
+                Ok(body)
+            }
+        })
+        .and_then(
+            move |body| -> Box<dyn Future<Item = HttpResponse, Error = Error>> {
+                let r_obj = serde_json::from_slice::<(String, String)>(&body);
+                match r_obj {
+                    Ok((tag, key)) => {
+                        let m_obj = InternalSshKeyCreateMessage {
+                            uat: uat,
+                            uuid_or_name: id,
+                            tag: tag,
+                            key: key,
+                            filter: filter_all!(f_eq("class", PartialValue::new_class("account"))),
+                        };
+                        // Add a msg here
+                        let res = state.qe_w.send(m_obj).from_err().and_then(|res| match res {
+                            Ok(_) => Ok(HttpResponse::Ok().json(())),
+                            Err(e) => Ok(operation_error_to_response(e)),
+                        });
+
+                        Box::new(res)
+                    }
+                    Err(e) => Box::new(future::err(error::ErrorBadRequest(format!(
+                        "Json Decode Failed: {:?}",
+                        e
+                    )))),
+                } // end match
+            },
+        ) // end and_then
+}
+
+fn account_get_id_ssh_pubkey_tag(
+    (path, req, state): (Path<(String, String)>, HttpRequest<AppState>, State<AppState>),
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let uat = get_current_user(&req);
+    let (id, tag) = path.into_inner();
+
+    let obj = InternalSshKeyTagReadMessage {
+        uat: uat,
+        uuid_or_name: id,
+        tag: tag,
+    };
+
+    let res = state.qe_r.send(obj).from_err().and_then(|res| match res {
+        Ok(event_result) => {
+            // Only send back the first result, or None
+            Ok(HttpResponse::Ok().json(event_result))
+        }
+        Err(e) => Ok(operation_error_to_response(e)),
+    });
+
+    Box::new(res)
+}
+
+fn account_delete_id_ssh_pubkey_tag(
+    (path, req, state): (Path<(String, String)>, HttpRequest<AppState>, State<AppState>),
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let uat = get_current_user(&req);
+    let (id, tag) = path.into_inner();
+
+    let obj = RemoveAttributeValueMessage {
+        uat: uat,
+        uuid_or_name: id,
+        attr: "ssh_publickey".to_string(),
+        value: tag,
+        filter: filter_all!(f_eq("class", PartialValue::new_class("account"))),
+    };
+
+    let res = state.qe_w.send(obj).from_err().and_then(|res| match res {
+        Ok(event_result) => {
             Ok(HttpResponse::Ok().json(event_result))
         }
         Err(e) => Ok(operation_error_to_response(e)),
@@ -1510,16 +1605,14 @@ pub fn create_server_core(config: Configuration) {
         .resource("/v1/account/{id}/_ssh_pubkeys", |r| {
             r.method(http::Method::GET)
                 .with_async(account_get_id_ssh_pubkeys);
-            // r.method(http::Method::POST)
-            //    .with_async(account_post_id_ssh_pubkey);
+            r.method(http::Method::POST)
+                .with_async(account_post_id_ssh_pubkey);
         })
-        .resource("/v1/account/{id}/_ssh_pubkeys/{tag}", |_r| {
-            // r.method(http::Method::GET)
-            //     .with_async(account_get_id_ssh_pubkey_tag);
-            // r.method(http::Method::DELETE)
-            //     .with_async(account_delete_id_ssh_pubkey_tag);
-            // r.method(http::Method::PUT)
-            //     .with_async(account_put_id_ssh_pubkey_tag);
+        .resource("/v1/account/{id}/_ssh_pubkeys/{tag}", |r| {
+            r.method(http::Method::GET)
+                .with_async(account_get_id_ssh_pubkey_tag);
+            r.method(http::Method::DELETE)
+                .with_async(account_delete_id_ssh_pubkey_tag);
         })
         .resource("/v1/account/{id}/_radius", |r| {
             r.method(http::Method::GET)

--- a/kanidmd/src/lib/core.rs
+++ b/kanidmd/src/lib/core.rs
@@ -17,14 +17,14 @@ use crate::config::Configuration;
 use crate::actors::v1_read::QueryServerReadV1;
 use crate::actors::v1_read::{
     AuthMessage, InternalRadiusReadMessage, InternalRadiusTokenReadMessage, InternalSearchMessage,
-    SearchMessage, WhoamiMessage, InternalSshKeyReadMessage, InternalSshKeyTagReadMessage
+    InternalSshKeyReadMessage, InternalSshKeyTagReadMessage, SearchMessage, WhoamiMessage,
 };
 use crate::actors::v1_write::QueryServerWriteV1;
 use crate::actors::v1_write::{
     AppendAttributeMessage, CreateMessage, DeleteMessage, IdmAccountSetPasswordMessage,
     InternalCredentialSetMessage, InternalDeleteMessage, InternalRegenerateRadiusMessage,
-    ModifyMessage, PurgeAttributeMessage, SetAttributeMessage, RemoveAttributeValueMessage,
-    InternalSshKeyCreateMessage
+    InternalSshKeyCreateMessage, ModifyMessage, PurgeAttributeMessage, RemoveAttributeValueMessage,
+    SetAttributeMessage,
 };
 use crate::async_log;
 use crate::audit::AuditScope;
@@ -777,7 +777,11 @@ fn account_post_id_ssh_pubkey(
 }
 
 fn account_get_id_ssh_pubkey_tag(
-    (path, req, state): (Path<(String, String)>, HttpRequest<AppState>, State<AppState>),
+    (path, req, state): (
+        Path<(String, String)>,
+        HttpRequest<AppState>,
+        State<AppState>,
+    ),
 ) -> impl Future<Item = HttpResponse, Error = Error> {
     let uat = get_current_user(&req);
     let (id, tag) = path.into_inner();
@@ -800,7 +804,11 @@ fn account_get_id_ssh_pubkey_tag(
 }
 
 fn account_delete_id_ssh_pubkey_tag(
-    (path, req, state): (Path<(String, String)>, HttpRequest<AppState>, State<AppState>),
+    (path, req, state): (
+        Path<(String, String)>,
+        HttpRequest<AppState>,
+        State<AppState>,
+    ),
 ) -> impl Future<Item = HttpResponse, Error = Error> {
     let uat = get_current_user(&req);
     let (id, tag) = path.into_inner();
@@ -814,9 +822,7 @@ fn account_delete_id_ssh_pubkey_tag(
     };
 
     let res = state.qe_w.send(obj).from_err().and_then(|res| match res {
-        Ok(event_result) => {
-            Ok(HttpResponse::Ok().json(event_result))
-        }
+        Ok(event_result) => Ok(HttpResponse::Ok().json(event_result)),
         Err(e) => Ok(operation_error_to_response(e)),
     });
 

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -1253,6 +1253,19 @@ impl<VALID, STATE> Entry<VALID, STATE> {
             .and_then(|a| a.get_radius_secret())
     }
 
+    pub fn get_ava_ssh_pubkeys(&self, attr: &str) -> Vec<String> {
+        match self.attrs.get(attr) {
+            Some(ava) => {
+                ava.iter()
+                    .filter_map(|v| {
+                        v.get_sshkey()
+                    })
+                    .collect()
+            }
+            None => Vec::new(),
+        }
+    }
+
     /*
     /// This interface will get &str (if possible).
     pub(crate) fn get_ava_opt_str(&self, attr: &str) -> Option<Vec<&str>> {

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -1255,13 +1255,7 @@ impl<VALID, STATE> Entry<VALID, STATE> {
 
     pub fn get_ava_ssh_pubkeys(&self, attr: &str) -> Vec<String> {
         match self.attrs.get(attr) {
-            Some(ava) => {
-                ava.iter()
-                    .filter_map(|v| {
-                        v.get_sshkey()
-                    })
-                    .collect()
-            }
+            Some(ava) => ava.iter().filter_map(|v| v.get_sshkey()).collect(),
             None => Vec::new(),
         }
     }

--- a/kanidmd/src/lib/event.rs
+++ b/kanidmd/src/lib/event.rs
@@ -10,7 +10,7 @@ use kanidm_proto::v1::{
     WhoamiResponse,
 };
 // use error::OperationError;
-use crate::modify::{ModifyList, ModifyValid, ModifyInvalid};
+use crate::modify::{ModifyInvalid, ModifyList, ModifyValid};
 use crate::server::{
     QueryServerReadTransaction, QueryServerTransaction, QueryServerWriteTransaction,
 };

--- a/kanidmd/src/lib/modify.rs
+++ b/kanidmd/src/lib/modify.rs
@@ -91,6 +91,10 @@ impl ModifyList<ModifyInvalid> {
         Self::new_list(vec![m_purge(attr), Modify::Present(attr.to_string(), v)])
     }
 
+    pub fn new_append(attr: &str, v: Value) -> Self {
+        Self::new_list(vec![Modify::Present(attr.to_string(), v)])
+    }
+
     pub fn new_purge(attr: &str) -> Self {
         Self::new_list(vec![m_purge(attr)])
     }

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -258,9 +258,15 @@ impl SchemaAttribute {
         let r = v.validate();
         // TODO: Fix this validation - I think due to the design of Value it may not
         // be possible for this to fail due to how we parse.
-        assert!(r);
-        let pv: &PartialValue = v.borrow();
-        self.validate_partialvalue(pv)
+        if cfg!(test) {
+            assert!(r);
+        }
+        if r {
+            let pv: &PartialValue = v.borrow();
+            self.validate_partialvalue(pv)
+        } else {
+            Err(SchemaError::InvalidAttributeSyntax)
+        }
     }
 
     pub fn validate_ava(&self, ava: &BTreeSet<Value>) -> Result<(), SchemaError> {

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use uuid::Uuid;
 
 use std::cmp::Ordering;
+use sshkeys::PublicKey as SshPublicKey;
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
@@ -762,6 +763,13 @@ impl Value {
         }
     }
 
+    pub fn new_sshkey_str(tag: &str, key: &str) -> Self {
+        Value {
+            pv: PartialValue::new_sshkey_tag_s(tag),
+            data: Some(DataValue::SshKey(key.to_string())),
+        }
+    }
+
     pub fn is_sshkey(&self) -> bool {
         match &self.pv {
             PartialValue::SshKey(_) => true,
@@ -975,7 +983,26 @@ impl Value {
                 // tag to the proto side. The credentials private data is stored seperately.
                 tag.to_string()
             }
-            PartialValue::SshKey(tag) => tag.to_string(),
+            // We display the tag and fingerprint.
+            PartialValue::SshKey(tag) => match &self.data {
+                Some(v) => match &v {
+                    DataValue::SshKey(sk) => {
+                        // Check it's really an sshkey in the
+                        // supplemental data.
+                        match SshPublicKey::from_string(sk) {
+                            Ok(spk) => {
+                                let fp = spk.fingerprint();
+                                format!("{}: {}", tag, fp.hash)
+                            }
+                            Err(_) => format!("{}: corrupted ssh public key", tag),
+                        }
+                    }
+                    _ => format!("{}: corrupted value tag", tag),
+                },
+                None => format!("{}: corrupted value", tag),
+            },
+            // We don't disclose the radius credential unless by special
+            // interfaces.
             PartialValue::RadiusCred => "radius".to_string(),
         }
     }
@@ -994,7 +1021,14 @@ impl Value {
             },
             PartialValue::SshKey(_) => match &self.data {
                 Some(v) => match &v {
-                    DataValue::SshKey(_) => true,
+                    DataValue::SshKey(sk) => {
+                        // Check it's really an sshkey in the
+                        // supplemental data.
+                        match SshPublicKey::from_string(sk) {
+                            Ok(_) => true,
+                            Err(_) => false,
+                        }
+                    }
                     _ => false,
                 },
                 None => false,
@@ -1022,7 +1056,10 @@ impl Value {
             PartialValue::JsonFilt(s) => vec![serde_json::to_string(s)
                 .expect("A json filter value was corrupted during run-time")],
             PartialValue::Cred(tag) => vec![tag.to_string()],
-            PartialValue::SshKey(tag) => vec![tag.to_string()],
+            PartialValue::SshKey(tag) => {
+                // Should this also extract the key data?
+                vec![tag.to_string()]
+            }
             PartialValue::RadiusCred => vec![],
         }
     }
@@ -1072,6 +1109,43 @@ mod tests {
 
         let r6 = SyntaxType::try_from("zzzzantheou");
         assert_eq!(r6, Err(()));
+    }
+
+    #[test]
+    fn test_value_sshkey_validation_display() {
+        let ecdsa = concat!("ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAGyIY7o3B",
+        "tOzRiJ9vvjj96bRImwmyy5GvFSIUPlK00HitiAWGhiO1jGZKmK7220Oe4rqU3uAwA00a0758UODs+0OQHLMDRtl81l",
+        "zPrVSdrYEDldxH9+a86dBZhdm0e15+ODDts2LHUknsJCRRldO4o9R9VrohlF7cbyBlnhJQrR4S+Oag== william@a",
+        "methyst");
+        let ed25519 = concat!("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAeGW1P6Pc2rPq0XqbRaDKBcXZUPRklo0L1EyR30CwoP",
+        " william@amethyst");
+        let rsa = concat!("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTcXpclurQpyOHZBM/cDY9EvInSYkYSGe51by/wJP0Njgi",
+        "GZUJ3HTaPqoGWux0PKd7KJki+onLYt4IwDV1RhV/GtMML2U9v94+pA8RIK4khCxvpUxlM7Kt/svjOzzzqiZfKdV37/",
+        "OUXmM7bwVGOvm3EerDOwmO/QdzNGfkca12aWLoz97YrleXnCoAzr3IN7j3rwmfJGDyuUtGTdmyS/QWhK9FPr8Ic3eM",
+        "QK1JSAQqVfGhA8lLbJHmnQ/b/KMl2lzzp7SXej0wPUfvI/IP3NGb8irLzq8+JssAzXGJ+HMql+mNHiSuPaktbFzZ6y",
+        "ikMR6Rx/psU07nAkxKZDEYpNVv william@amethyst");
+
+        let sk1 = Value::new_sshkey_str("tag", ecdsa);
+        assert!(sk1.validate());
+        // to proto them
+        let psk1 = sk1.to_proto_string_clone();
+        assert_eq!(psk1, "tag: oMh0SibdRGV2APapEdVojzSySx9PuhcklWny5LP0Mg4");
+
+        let sk2 = Value::new_sshkey_str("tag", ed25519);
+        assert!(sk2.validate());
+        let psk2 = sk2.to_proto_string_clone();
+        assert_eq!(psk2, "tag: UR7mRCLLXmZNsun+F2lWO3hG3PORk/0JyjxPQxDUcdc");
+
+        let sk3 = Value::new_sshkey_str("tag", rsa);
+        assert!(sk3.validate());
+        let psk3 = sk3.to_proto_string_clone();
+        assert_eq!(psk3, "tag: sWugDdWeE4LkmKer8hz7ERf+6VttYPIqD0ULXR3EUcU");
+
+        let sk4 = Value::new_sshkey_str("tag", "ntaouhtnhtnuehtnuhotnuhtneouhtneouh");
+        assert!(!sk4.validate());
+
+        let sk5 = Value::new_sshkey_str("tag", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAeGW1P6Pc2rPq0XqbRaDKBcXZUPRklo");
+        assert!(!sk5.validate());
     }
 
     /*

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -359,6 +359,10 @@ impl PartialValue {
         }
     }
 
+    pub fn new_sshkey_tag(s: String) -> Self {
+        PartialValue::SshKey(s)
+    }
+
     pub fn new_sshkey_tag_s(s: &str) -> Self {
         PartialValue::SshKey(s.to_string())
     }
@@ -770,6 +774,13 @@ impl Value {
         }
     }
 
+    pub fn new_sshkey(tag: String, key: String) -> Self {
+        Value {
+            pv: PartialValue::new_sshkey_tag(tag),
+            data: Some(DataValue::SshKey(key)),
+        }
+    }
+
     pub fn is_sshkey(&self) -> bool {
         match &self.pv {
             PartialValue::SshKey(_) => true,
@@ -1081,6 +1092,13 @@ impl Value {
 }
 
 impl Borrow<PartialValue> for Value {
+    fn borrow(&self) -> &PartialValue {
+        &self.pv
+    }
+}
+
+// Allows sets of value refs to be compared to PV's
+impl Borrow<PartialValue> for &Value {
     fn borrow(&self) -> &PartialValue {
         &self.pv
     }

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -777,6 +777,21 @@ impl Value {
         }
     }
 
+    pub fn get_sshkey(&self) -> Option<String> {
+        match &self.pv {
+            PartialValue::SshKey(_) => {
+                match &self.data {
+                    Some(v) => match &v {
+                        DataValue::SshKey(sc) => Some(sc.clone()),
+                        _ => None,
+                    },
+                    None => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
     pub fn contains(&self, s: &PartialValue) -> bool {
         self.pv.contains(s)
     }

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -7,8 +7,8 @@ use std::convert::TryFrom;
 use std::str::FromStr;
 use uuid::Uuid;
 
-use std::cmp::Ordering;
 use sshkeys::PublicKey as SshPublicKey;
+use std::cmp::Ordering;
 
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
@@ -790,15 +790,13 @@ impl Value {
 
     pub fn get_sshkey(&self) -> Option<String> {
         match &self.pv {
-            PartialValue::SshKey(_) => {
-                match &self.data {
-                    Some(v) => match &v {
-                        DataValue::SshKey(sc) => Some(sc.clone()),
-                        _ => None,
-                    },
-                    None => None,
-                }
-            }
+            PartialValue::SshKey(_) => match &self.data {
+                Some(v) => match &v {
+                    DataValue::SshKey(sc) => Some(sc.clone()),
+                    _ => None,
+                },
+                None => None,
+            },
             _ => None,
         }
     }
@@ -1150,8 +1148,10 @@ mod tests {
         "tOzRiJ9vvjj96bRImwmyy5GvFSIUPlK00HitiAWGhiO1jGZKmK7220Oe4rqU3uAwA00a0758UODs+0OQHLMDRtl81l",
         "zPrVSdrYEDldxH9+a86dBZhdm0e15+ODDts2LHUknsJCRRldO4o9R9VrohlF7cbyBlnhJQrR4S+Oag== william@a",
         "methyst");
-        let ed25519 = concat!("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAeGW1P6Pc2rPq0XqbRaDKBcXZUPRklo0L1EyR30CwoP",
-        " william@amethyst");
+        let ed25519 = concat!(
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAeGW1P6Pc2rPq0XqbRaDKBcXZUPRklo0L1EyR30CwoP",
+            " william@amethyst"
+        );
         let rsa = concat!("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTcXpclurQpyOHZBM/cDY9EvInSYkYSGe51by/wJP0Njgi",
         "GZUJ3HTaPqoGWux0PKd7KJki+onLYt4IwDV1RhV/GtMML2U9v94+pA8RIK4khCxvpUxlM7Kt/svjOzzzqiZfKdV37/",
         "OUXmM7bwVGOvm3EerDOwmO/QdzNGfkca12aWLoz97YrleXnCoAzr3IN7j3rwmfJGDyuUtGTdmyS/QWhK9FPr8Ic3eM",
@@ -1177,7 +1177,10 @@ mod tests {
         let sk4 = Value::new_sshkey_str("tag", "ntaouhtnhtnuehtnuhotnuhtneouhtneouh");
         assert!(!sk4.validate());
 
-        let sk5 = Value::new_sshkey_str("tag", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAeGW1P6Pc2rPq0XqbRaDKBcXZUPRklo");
+        let sk5 = Value::new_sshkey_str(
+            "tag",
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAeGW1P6Pc2rPq0XqbRaDKBcXZUPRklo",
+        );
         assert!(!sk5.validate());
     }
 


### PR DESCRIPTION
Implements #126 ssh key distribution features. This adds an improved SSH key validator, and the related REST endpoints for SSH keys management due to being a non-trivial type for parsing - we could consider a str -> json instead for future to avoid the custom routines perhaps. This also adds a tool for openssh to consume by the AuthorizedKeysCommand in sshd_config, which gets and lists keys as such:

```
kanidm_ssh_authorizedkeys admin -H https://localhost:8080 -D anonymous -C ../insecure/ca.pem
ssh-ed25519 AAAC3NzaC1lZDI1NTE5AAAAIAeGW1P6Pc2rPq0XqbRaDKBcXZUPRklo0L1EyR30CwoP william@amethyst
```

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ - ] design document included (if relevant)
