### PR TITLE
127 domain info type

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -33,10 +33,14 @@ Then you can setup the initial admin account and initialise the database into yo
 
     docker run --rm -i -t -v kanidmd:/data firstyear/kanidmd:latest /home/kanidm/target/release/kanidmd recover_account -D /data/kanidm.db -n admin
 
-You can now run the server - note that we provide all the options on the cli, but this pattern
-may change in the future.
+You then want to set your domain name:
 
-    docker run -p 8443:8443 -v /Users/william/development/rsidm/insecure:/data firstyear/kanidmd:latest /home/kanidm/target/release/kanidmd server -D /data/kanidm.db -C /data/ca.pem -c /data/cert.pem -k /data/key.pem --bindaddr 0.0.0.0:8443 --domain localhost
+    docker run --rm -i -t -v kanidmd:/data firstyear/kanidmd:latest /home/kanidm/target/release/kanidmd domain_name_change -D /data/kanidm.db -n idm.example.com
+
+Now we can run the server. Previously we had to specify all options, but now domain_name is part of
+the database.
+
+    docker run -p 8443:8443 -v /Users/william/development/rsidm/insecure:/data firstyear/kanidmd:latest
 
 # Using the cli
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can now build and run the server with:
 
     cd kanidmd
     cargo run -- recover_account -D /tmp/kanidm.db -n admin
-    cargo run -- server -D /tmp/kanidm.db -C ../insecure/ca.pem -c ../insecure/cert.pem -k ../insecure/key.pem --domain localhost --bindaddr 127.0.0.1:8080
+    cargo run -- server -D /tmp/kanidm.db -C ../insecure/ca.pem -c ../insecure/cert.pem -k ../insecure/key.pem --bindaddr 127.0.0.1:8080
 
 In a new terminal, you can now build and run the client tools with:
 

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -598,6 +598,32 @@ impl KanidmClient {
         self.perform_delete_request(format!("/v1/account/{}/_ssh_pubkeys/{}", id, tag).as_str())
     }
 
+
+    // ==== domain_info (aka domain)
+    pub fn idm_domain_list(&self) -> Result<Vec<Entry>, ClientError> {
+        self.perform_get_request("/v1/domain")
+    }
+
+    pub fn idm_domain_get(&self, id: &str) -> Result<Entry, ClientError> {
+        self.perform_get_request(format!("/v1/domain/{}", id).as_str())
+    }
+
+    // pub fn idm_domain_get_attr
+    pub fn idm_domain_get_ssid(&self, id: &str) -> Result<String, ClientError> {
+        self.perform_get_request(format!("/v1/domain/{}/_attr/domain_ssid", id).as_str())
+            .and_then(|mut r: Vec<String>| {
+                Ok(r.pop().unwrap())
+            })
+    }
+
+    // pub fn idm_domain_put_attr
+    pub fn idm_domain_set_ssid(&self, id: &str, ssid: &str) -> Result<(), ClientError> {
+        self.perform_put_request(
+            format!("/v1/domain/{}/_attr/domain_ssid", id).as_str(),
+            vec![ssid.to_string()],
+        )
+    }
+
     // ==== schema
     pub fn idm_schema_list(&self) -> Result<Vec<Entry>, ClientError> {
         self.perform_get_request("/v1/schema")

--- a/kanidm_client/src/lib.rs
+++ b/kanidm_client/src/lib.rs
@@ -598,7 +598,6 @@ impl KanidmClient {
         self.perform_delete_request(format!("/v1/account/{}/_ssh_pubkeys/{}", id, tag).as_str())
     }
 
-
     // ==== domain_info (aka domain)
     pub fn idm_domain_list(&self) -> Result<Vec<Entry>, ClientError> {
         self.perform_get_request("/v1/domain")
@@ -611,9 +610,7 @@ impl KanidmClient {
     // pub fn idm_domain_get_attr
     pub fn idm_domain_get_ssid(&self, id: &str) -> Result<String, ClientError> {
         self.perform_get_request(format!("/v1/domain/{}/_attr/domain_ssid", id).as_str())
-            .and_then(|mut r: Vec<String>| {
-                Ok(r.pop().unwrap())
-            })
+            .and_then(|mut r: Vec<String>| Ok(r.pop().unwrap()))
     }
 
     // pub fn idm_domain_put_attr

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -534,8 +534,7 @@ fn test_server_rest_domain_lifecycle() {
         let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
         assert!(res.is_ok());
 
-        let mut dlist = rsclient.idm_domain_list()
-            .unwrap();
+        let mut dlist = rsclient.idm_domain_list().unwrap();
         assert!(dlist.len() == 1);
 
         let dlocal = rsclient.idm_domain_get("domain_local").unwrap();
@@ -543,13 +542,14 @@ fn test_server_rest_domain_lifecycle() {
         assert!(dlist.pop().unwrap().attrs == dlocal.attrs);
 
         // Change the ssid
-        rsclient.idm_domain_set_ssid("domain_local", "new_ssid").unwrap();
+        rsclient
+            .idm_domain_set_ssid("domain_local", "new_ssid")
+            .unwrap();
         // check get and get the ssid and domain info
         let nssid = rsclient.idm_domain_get_ssid("domain_local").unwrap();
         assert!(nssid == "new_ssid");
     });
 }
-
 
 // Test the self version of the radius path.
 

--- a/kanidm_client/tests/proto_v1_test.rs
+++ b/kanidm_client/tests/proto_v1_test.rs
@@ -528,6 +528,29 @@ fn test_server_rest_sshkey_lifecycle() {
     });
 }
 
+#[test]
+fn test_server_rest_domain_lifecycle() {
+    run_test(|rsclient: KanidmClient| {
+        let res = rsclient.auth_simple_password("admin", ADMIN_TEST_PASSWORD);
+        assert!(res.is_ok());
+
+        let mut dlist = rsclient.idm_domain_list()
+            .unwrap();
+        assert!(dlist.len() == 1);
+
+        let dlocal = rsclient.idm_domain_get("domain_local").unwrap();
+        // There should be one, and it's the domain_local
+        assert!(dlist.pop().unwrap().attrs == dlocal.attrs);
+
+        // Change the ssid
+        rsclient.idm_domain_set_ssid("domain_local", "new_ssid").unwrap();
+        // check get and get the ssid and domain info
+        let nssid = rsclient.idm_domain_get_ssid("domain_local").unwrap();
+        assert!(nssid == "new_ssid");
+    });
+}
+
+
 // Test the self version of the radius path.
 
 // Test hitting all auth-required endpoints and assert they give unauthorized.

--- a/kanidm_proto/src/v1.rs
+++ b/kanidm_proto/src/v1.rs
@@ -72,6 +72,7 @@ pub enum ConsistencyError {
     MemberOfInvalid(u64),
     InvalidAttributeType(String),
     DuplicateUniqueAttribute(String),
+    InvalidSPN(u64),
 }
 
 /* ===== higher level types ===== */

--- a/kanidmd/src/lib/be/dbvalue.rs
+++ b/kanidmd/src/lib/be/dbvalue.rs
@@ -37,4 +37,5 @@ pub enum DbValueV1 {
     CR(DbValueCredV1),
     RU(String),
     SK(DbValueTaggedStringV1),
+    SP(String, String),
 }

--- a/kanidmd/src/lib/config.rs
+++ b/kanidmd/src/lib/config.rs
@@ -18,7 +18,6 @@ pub struct TlsConfiguration {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Configuration {
     pub address: String,
-    pub domain: String,
     pub threads: usize,
     // db type later
     pub db_path: String,
@@ -32,7 +31,6 @@ pub struct Configuration {
 impl fmt::Display for Configuration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "address: {}, ", self.address)
-            .and_then(|_| write!(f, "domain: {}, ", self.domain))
             .and_then(|_| write!(f, "thread count: {}, ", self.threads))
             .and_then(|_| write!(f, "dbpath: {}, ", self.db_path))
             .and_then(|_| write!(f, "max request size: {}b, ", self.maximum_request))
@@ -52,7 +50,6 @@ impl Configuration {
     pub fn new() -> Self {
         let mut c = Configuration {
             address: String::from("127.0.0.1:8080"),
-            domain: String::from("localhost"),
             threads: num_cpus::get(),
             db_path: String::from(""),
             maximum_request: 262144, // 256k

--- a/kanidmd/src/lib/constants.rs
+++ b/kanidmd/src/lib/constants.rs
@@ -11,9 +11,147 @@ pub static PURGE_TIMEOUT: u64 = 3600;
 // 5 minute auth session window.
 pub static AUTH_SESSION_TIMEOUT: u64 = 300;
 
+// Built in group and account ranges.
 pub static STR_UUID_ADMIN: &'static str = "00000000-0000-0000-0000-000000000000";
-pub static STR_UUID_ANONYMOUS: &'static str = "00000000-0000-0000-0000-ffffffffffff";
+pub static _UUID_IDM_ADMINS: &'static str = "00000000-0000-0000-0000-000000000001";
+pub static _UUID_IDM_PEOPLE_READ_PRIV: &'static str = "00000000-0000-0000-0000-000000000002";
+pub static _UUID_IDM_PEOPLE_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000003";
+pub static _UUID_IDM_GROUP_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000004";
+pub static _UUID_IDM_ACCOUNT_READ_PRIV: &'static str = "00000000-0000-0000-0000-000000000005";
+pub static _UUID_IDM_ACCOUNT_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000006";
+pub static _UUID_IDM_RADIUS_SERVERS: &'static str = "00000000-0000-0000-0000-000000000007";
+pub static _UUID_IDM_HP_ACCOUNT_READ_PRIV: &'static str = "00000000-0000-0000-0000-000000000008";
+pub static _UUID_IDM_HP_ACCOUNT_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000009";
+pub static _UUID_IDM_SCHEMA_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000010";
+pub static _UUID_IDM_ACP_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000011";
+pub static _UUID_IDM_HP_GROUP_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000012";
+pub static _UUID_IDM_PEOPLE_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000013";
+pub static _UUID_IDM_ACCOUNT_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000014";
+pub static _UUID_IDM_GROUP_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000015";
+pub static _UUID_IDM_HP_ACCOUNT_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000016";
+pub static _UUID_IDM_HP_GROUP_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000017";
+pub static _UUID_IDM_ADMIN_V1: &'static str = "00000000-0000-0000-0000-000000000018";
+pub static _UUID_SYSTEM_ADMINS: &'static str = "00000000-0000-0000-0000-000000000019";
+//
+pub static _UUID_IDM_HIGH_PRIVILEGE: &'static str = "00000000-0000-0000-0000-000000001000";
+
+// Builtin schema
+pub static UUID_SCHEMA_ATTR_CLASS: &'static str = "00000000-0000-0000-0000-ffff00000000";
+pub static UUID_SCHEMA_ATTR_UUID: &'static str = "00000000-0000-0000-0000-ffff00000001";
+pub static UUID_SCHEMA_ATTR_NAME: &'static str = "00000000-0000-0000-0000-ffff00000002";
+pub static UUID_SCHEMA_ATTR_PRINCIPAL_NAME: &'static str = "00000000-0000-0000-0000-ffff00000003";
+pub static UUID_SCHEMA_ATTR_DESCRIPTION: &'static str = "00000000-0000-0000-0000-ffff00000004";
+pub static UUID_SCHEMA_ATTR_MULTIVALUE: &'static str = "00000000-0000-0000-0000-ffff00000005";
+pub static UUID_SCHEMA_ATTR_UNIQUE: &'static str = "00000000-0000-0000-0000-ffff00000047";
+pub static UUID_SCHEMA_ATTR_INDEX: &'static str = "00000000-0000-0000-0000-ffff00000006";
+pub static UUID_SCHEMA_ATTR_SYNTAX: &'static str = "00000000-0000-0000-0000-ffff00000007";
+pub static UUID_SCHEMA_ATTR_SYSTEMMAY: &'static str = "00000000-0000-0000-0000-ffff00000008";
+pub static UUID_SCHEMA_ATTR_MAY: &'static str = "00000000-0000-0000-0000-ffff00000009";
+pub static UUID_SCHEMA_ATTR_SYSTEMMUST: &'static str = "00000000-0000-0000-0000-ffff00000010";
+pub static UUID_SCHEMA_ATTR_MUST: &'static str = "00000000-0000-0000-0000-ffff00000011";
+pub static UUID_SCHEMA_ATTR_MEMBEROF: &'static str = "00000000-0000-0000-0000-ffff00000012";
+pub static UUID_SCHEMA_ATTR_MEMBER: &'static str = "00000000-0000-0000-0000-ffff00000013";
+pub static UUID_SCHEMA_ATTR_DIRECTMEMBEROF: &'static str = "00000000-0000-0000-0000-ffff00000014";
+pub static UUID_SCHEMA_ATTR_VERSION: &'static str = "00000000-0000-0000-0000-ffff00000015";
+pub static UUID_SCHEMA_ATTR_DOMAIN: &'static str = "00000000-0000-0000-0000-ffff00000016";
+pub static UUID_SCHEMA_ATTR_ACP_ENABLE: &'static str = "00000000-0000-0000-0000-ffff00000017";
+pub static UUID_SCHEMA_ATTR_ACP_RECEIVER: &'static str = "00000000-0000-0000-0000-ffff00000018";
+pub static UUID_SCHEMA_ATTR_ACP_TARGETSCOPE: &'static str = "00000000-0000-0000-0000-ffff00000019";
+pub static UUID_SCHEMA_ATTR_ACP_SEARCH_ATTR: &'static str = "00000000-0000-0000-0000-ffff00000020";
+pub static UUID_SCHEMA_ATTR_ACP_CREATE_CLASS: &'static str = "00000000-0000-0000-0000-ffff00000021";
+pub static UUID_SCHEMA_ATTR_ACP_CREATE_ATTR: &'static str = "00000000-0000-0000-0000-ffff00000022";
+pub static UUID_SCHEMA_ATTR_ACP_MODIFY_REMOVEDATTR: &'static str =
+    "00000000-0000-0000-0000-ffff00000023";
+pub static UUID_SCHEMA_ATTR_ACP_MODIFY_PRESENTATTR: &'static str =
+    "00000000-0000-0000-0000-ffff00000024";
+pub static UUID_SCHEMA_ATTR_ACP_MODIFY_CLASS: &'static str = "00000000-0000-0000-0000-ffff00000025";
+pub static UUID_SCHEMA_CLASS_ATTRIBUTETYPE: &'static str = "00000000-0000-0000-0000-ffff00000026";
+pub static UUID_SCHEMA_CLASS_CLASSTYPE: &'static str = "00000000-0000-0000-0000-ffff00000027";
+pub static UUID_SCHEMA_CLASS_OBJECT: &'static str = "00000000-0000-0000-0000-ffff00000028";
+pub static UUID_SCHEMA_CLASS_EXTENSIBLEOBJECT: &'static str =
+    "00000000-0000-0000-0000-ffff00000029";
+pub static UUID_SCHEMA_CLASS_MEMBEROF: &'static str = "00000000-0000-0000-0000-ffff00000030";
+pub static UUID_SCHEMA_CLASS_RECYCLED: &'static str = "00000000-0000-0000-0000-ffff00000031";
+pub static UUID_SCHEMA_CLASS_TOMBSTONE: &'static str = "00000000-0000-0000-0000-ffff00000032";
+pub static UUID_SCHEMA_CLASS_SYSTEM_INFO: &'static str = "00000000-0000-0000-0000-ffff00000033";
+pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_PROFILE: &'static str =
+    "00000000-0000-0000-0000-ffff00000034";
+pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_SEARCH: &'static str =
+    "00000000-0000-0000-0000-ffff00000035";
+pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_DELETE: &'static str =
+    "00000000-0000-0000-0000-ffff00000036";
+pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_MODIFY: &'static str =
+    "00000000-0000-0000-0000-ffff00000037";
+pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_CREATE: &'static str =
+    "00000000-0000-0000-0000-ffff00000038";
+pub static UUID_SCHEMA_CLASS_SYSTEM: &'static str = "00000000-0000-0000-0000-ffff00000039";
+pub static UUID_SCHEMA_ATTR_DISPLAYNAME: &'static str = "00000000-0000-0000-0000-ffff00000040";
+pub static UUID_SCHEMA_ATTR_MAIL: &'static str = "00000000-0000-0000-0000-ffff00000041";
+pub static UUID_SCHEMA_ATTR_SSH_PUBLICKEY: &'static str = "00000000-0000-0000-0000-ffff00000042";
+pub static UUID_SCHEMA_ATTR_PRIMARY_CREDENTIAL: &'static str =
+    "00000000-0000-0000-0000-ffff00000043";
+pub static UUID_SCHEMA_CLASS_PERSON: &'static str = "00000000-0000-0000-0000-ffff00000044";
+pub static UUID_SCHEMA_CLASS_GROUP: &'static str = "00000000-0000-0000-0000-ffff00000045";
+pub static UUID_SCHEMA_CLASS_ACCOUNT: &'static str = "00000000-0000-0000-0000-ffff00000046";
+// GAP - 47
+pub static UUID_SCHEMA_ATTR_ATTRIBUTENAME: &'static str = "00000000-0000-0000-0000-ffff00000048";
+pub static UUID_SCHEMA_ATTR_CLASSNAME: &'static str = "00000000-0000-0000-0000-ffff00000049";
+pub static UUID_SCHEMA_ATTR_LEGALNAME: &'static str = "00000000-0000-0000-0000-ffff00000050";
+pub static UUID_SCHEMA_ATTR_RADIUS_SECRET: &'static str = "00000000-0000-0000-0000-ffff00000051";
+pub static UUID_SCHEMA_CLASS_DOMAIN_INFO: &'static str = "00000000-0000-0000-0000-ffff00000052";
+pub static UUID_SCHEMA_ATTR_DOMAIN_NAME: &'static str = "00000000-0000-0000-0000-ffff00000053";
+pub static UUID_SCHEMA_ATTR_DOMAIN_UUID: &'static str = "00000000-0000-0000-0000-ffff00000054";
+pub static UUID_SCHEMA_ATTR_DOMAIN_SSID: &'static str = "00000000-0000-0000-0000-ffff00000055";
+
+// System and domain infos
+// I'd like to strongly criticise william of the past for fucking up these allocations.
+pub static _UUID_SYSTEM_INFO: &'static str = "00000000-0000-0000-0000-ffffff000001";
+pub static _UUID_DOMAIN_INFO: &'static str = "00000000-0000-0000-0000-ffffff000025";
+
+// Access controls
+// skip 00 / 01 - see system info
+pub static _UUID_IDM_ADMINS_ACP_RECYCLE_SEARCH_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000002";
+pub static _UUID_IDM_ADMINS_ACP_REVIVE_V1: &'static str = "00000000-0000-0000-0000-ffffff000003";
+pub static _UUID_IDM_SELF_ACP_READ_V1: &'static str = "00000000-0000-0000-0000-ffffff000004";
+pub static _UUID_IDM_ALL_ACP_READ_V1: &'static str = "00000000-0000-0000-0000-ffffff000006";
+pub static _UUID_IDM_ACP_PEOPLE_READ_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000007";
+pub static _UUID_IDM_ACP_PEOPLE_WRITE_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000008";
+pub static _UUID_IDM_ACP_GROUP_WRITE_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000009";
+pub static _UUID_IDM_ACP_ACCOUNT_READ_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000010";
+pub static _UUID_IDM_ACP_ACCOUNT_WRITE_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000011";
+pub static _UUID_IDM_ACP_ACCOUNT_MANAGE_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000012";
+pub static _UUID_IDM_ACP_PEOPLE_MANAGE_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000013";
+pub static _UUID_IDM_ACP_RADIUS_SERVERS_V1: &'static str = "00000000-0000-0000-0000-ffffff000014";
+pub static _UUID_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000015";
+pub static _UUID_IDM_ACP_HP_ACCOUNT_WRITE_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000016";
+pub static _UUID_IDM_ACP_HP_GROUP_WRITE_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000017";
+pub static _UUID_IDM_ACP_SCHEMA_WRITE_ATTRS_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000018";
+pub static _UUID_IDM_ACP_ACP_MANAGE_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000019";
+pub static _UUID_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000020";
+pub static _UUID_IDM_SELF_ACP_WRITE_V1: &'static str = "00000000-0000-0000-0000-ffffff000021";
+pub static _UUID_IDM_ACP_GROUP_MANAGE_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000022";
+pub static _UUID_IDM_ACP_HP_ACCOUNT_MANAGE_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000023";
+pub static _UUID_IDM_ACP_HP_GROUP_MANAGE_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000024";
+// Skip 25 - see domain info.
+
+// End of system ranges
 pub static STR_UUID_DOES_NOT_EXIST: &'static str = "00000000-0000-0000-0000-fffffffffffe";
+pub static STR_UUID_ANONYMOUS: &'static str = "00000000-0000-0000-0000-ffffffffffff";
+
 lazy_static! {
     pub static ref UUID_ADMIN: Uuid = Uuid::parse_str(STR_UUID_ADMIN).unwrap();
     pub static ref UUID_DOES_NOT_EXIST: Uuid = Uuid::parse_str(STR_UUID_DOES_NOT_EXIST).unwrap();
@@ -48,7 +186,6 @@ pub static JSON_IDM_ADMIN_V1: &'static str = r#"{
     }
 }"#;
 
-pub static _UUID_IDM_ADMINS: &'static str = "00000000-0000-0000-0000-000000000001";
 pub static JSON_IDM_ADMINS_V1: &'static str = r#"{
     "valid": {
         "uuid": "00000000-0000-0000-0000-000000000001"
@@ -63,7 +200,6 @@ pub static JSON_IDM_ADMINS_V1: &'static str = r#"{
     }
 }"#;
 
-pub static _UUID_SYSTEM_ADMINS: &'static str = "00000000-0000-0000-0000-000000000019";
 pub static JSON_SYSTEM_ADMINS_V1: &'static str = r#"{
     "valid": {
         "uuid": "00000000-0000-0000-0000-000000000019"
@@ -80,7 +216,6 @@ pub static JSON_SYSTEM_ADMINS_V1: &'static str = r#"{
 
 // groups
 // * People read managers
-pub static _UUID_IDM_PEOPLE_READ_PRIV: &'static str = "00000000-0000-0000-0000-000000000002";
 pub static JSON_IDM_PEOPLE_READ_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -91,7 +226,6 @@ pub static JSON_IDM_PEOPLE_READ_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // * People write managers
-pub static _UUID_IDM_PEOPLE_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000013";
 pub static JSON_IDM_PEOPLE_MANAGE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -103,7 +237,6 @@ pub static JSON_IDM_PEOPLE_MANAGE_PRIV_V1: &'static str = r#"{
         ]
     }
 }"#;
-pub static _UUID_IDM_PEOPLE_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000003";
 pub static JSON_IDM_PEOPLE_WRITE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -115,7 +248,6 @@ pub static JSON_IDM_PEOPLE_WRITE_PRIV_V1: &'static str = r#"{
 }"#;
 // * group write manager (no read, everyone has read via the anon, etc)
 // IDM_GROUP_CREATE_PRIV
-pub static _UUID_IDM_GROUP_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000015";
 pub static JSON_IDM_GROUP_MANAGE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -128,7 +260,6 @@ pub static JSON_IDM_GROUP_MANAGE_PRIV_V1: &'static str = r#"{
         ]
     }
 }"#;
-pub static _UUID_IDM_GROUP_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000004";
 pub static JSON_IDM_GROUP_WRITE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -141,7 +272,6 @@ pub static JSON_IDM_GROUP_WRITE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // * account read manager
-pub static _UUID_IDM_ACCOUNT_READ_PRIV: &'static str = "00000000-0000-0000-0000-000000000005";
 pub static JSON_IDM_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -154,7 +284,6 @@ pub static JSON_IDM_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // * account write manager
-pub static _UUID_IDM_ACCOUNT_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000014";
 pub static JSON_IDM_ACCOUNT_MANAGE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -166,7 +295,6 @@ pub static JSON_IDM_ACCOUNT_MANAGE_PRIV_V1: &'static str = r#"{
         ]
     }
 }"#;
-pub static _UUID_IDM_ACCOUNT_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000006";
 pub static JSON_IDM_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -177,7 +305,6 @@ pub static JSON_IDM_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // * RADIUS servers
-pub static _UUID_IDM_RADIUS_SERVERS: &'static str = "00000000-0000-0000-0000-000000000007";
 pub static JSON_IDM_RADIUS_SERVERS_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -187,7 +314,6 @@ pub static JSON_IDM_RADIUS_SERVERS_V1: &'static str = r#"{
     }
 }"#;
 // * high priv account read manager
-pub static _UUID_IDM_HP_ACCOUNT_READ_PRIV: &'static str = "00000000-0000-0000-0000-000000000008";
 pub static JSON_IDM_HP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -200,7 +326,6 @@ pub static JSON_IDM_HP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // * high priv account write manager
-pub static _UUID_IDM_HP_ACCOUNT_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000016";
 pub static JSON_IDM_HP_ACCOUNT_MANAGE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -212,7 +337,6 @@ pub static JSON_IDM_HP_ACCOUNT_MANAGE_PRIV_V1: &'static str = r#"{
         ]
     }
 }"#;
-pub static _UUID_IDM_HP_ACCOUNT_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000009";
 pub static JSON_IDM_HP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -225,7 +349,6 @@ pub static JSON_IDM_HP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // * Schema write manager
-pub static _UUID_IDM_SCHEMA_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000010";
 pub static JSON_IDM_SCHEMA_MANAGE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -238,7 +361,6 @@ pub static JSON_IDM_SCHEMA_MANAGE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // * ACP read/write manager
-pub static _UUID_IDM_ACP_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000011";
 pub static JSON_IDM_ACP_MANAGE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -249,7 +371,6 @@ pub static JSON_IDM_ACP_MANAGE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 
-pub static _UUID_IDM_HP_GROUP_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000017";
 pub static JSON_IDM_HP_GROUP_MANAGE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -259,7 +380,6 @@ pub static JSON_IDM_HP_GROUP_MANAGE_PRIV_V1: &'static str = r#"{
         "member": ["00000000-0000-0000-0000-000000000019"]
     }
 }"#;
-pub static _UUID_IDM_HP_GROUP_WRITE_PRIV: &'static str = "00000000-0000-0000-0000-000000000009";
 pub static JSON_IDM_HP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -273,7 +393,6 @@ pub static JSON_IDM_HP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
 }"#;
 
 // This must be the last group to init to include the UUID of the other high priv groups.
-pub static _UUID_IDM_HIGH_PRIVILEGE: &'static str = "00000000-0000-0000-0000-000000001000";
 pub static JSON_IDM_HIGH_PRIVILEGE_V1: &'static str = r#"{
     "attrs": {
         "class": ["group", "object"],
@@ -304,7 +423,6 @@ pub static JSON_IDM_HIGH_PRIVILEGE_V1: &'static str = r#"{
     }
 }"#;
 
-pub static _UUID_SYSTEM_INFO: &'static str = "00000000-0000-0000-0000-ffffff000001";
 pub static JSON_SYSTEM_INFO_V1: &'static str = r#"{
     "attrs": {
         "class": ["object", "system_info", "system"],
@@ -314,7 +432,6 @@ pub static JSON_SYSTEM_INFO_V1: &'static str = r#"{
     }
 }"#;
 
-pub static _UUID_DOMAIN_INFO: &'static str = "00000000-0000-0000-0000-ffffff000025";
 pub static JSON_DOMAIN_INFO_V1: &'static str = r#"{
     "attrs": {
         "class": ["object", "domain_info", "system"],
@@ -370,8 +487,6 @@ pub static JSON_IDM_ACP_XX_V1: &'static str = r#"{
 }"#;
 */
 
-pub static _UUID_IDM_ADMINS_ACP_RECYCLE_SEARCH_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000002";
 pub static JSON_IDM_ADMINS_ACP_RECYCLE_SEARCH_V1: &'static str = r#"{
     "attrs": {
         "class": ["object", "access_control_profile", "access_control_search"],
@@ -389,7 +504,6 @@ pub static JSON_IDM_ADMINS_ACP_RECYCLE_SEARCH_V1: &'static str = r#"{
     }
 }"#;
 
-pub static _UUID_IDM_ADMINS_ACP_REVIVE_V1: &'static str = "00000000-0000-0000-0000-ffffff000003";
 pub static JSON_IDM_ADMINS_ACP_REVIVE_V1: &'static str = r#"{
     "attrs": {
         "class": ["object", "access_control_profile", "access_control_modify"],
@@ -408,7 +522,6 @@ pub static JSON_IDM_ADMINS_ACP_REVIVE_V1: &'static str = r#"{
     }
 }"#;
 
-pub static _UUID_IDM_SELF_ACP_READ_V1: &'static str = "00000000-0000-0000-0000-ffffff000004";
 pub static JSON_IDM_SELF_ACP_READ_V1: &'static str = r#"{
     "attrs": {
         "class": ["object", "access_control_profile", "access_control_search"],
@@ -435,7 +548,6 @@ pub static JSON_IDM_SELF_ACP_READ_V1: &'static str = r#"{
     }
 }"#;
 
-pub static _UUID_IDM_SELF_ACP_WRITE_V1: &'static str = "00000000-0000-0000-0000-ffffff000021";
 pub static JSON_IDM_SELF_ACP_WRITE_V1: &'static str = r#"{
     "attrs": {
         "class": ["object", "access_control_profile", "access_control_modify"],
@@ -458,39 +570,6 @@ pub static JSON_IDM_SELF_ACP_WRITE_V1: &'static str = r#"{
     }
 }"#;
 
-/*
-pub static _UUID_IDM_ADMINS_ACP_MANAGE_V1: &'static str = "00000000-0000-0000-0000-ffffff000005";
-pub static JSON_IDM_ADMINS_ACP_MANAGE_V1: &'static str = r#"{
-    "attrs": {
-        "class": [
-            "object",
-            "access_control_profile",
-            "access_control_modify",
-            "access_control_create",
-            "access_control_delete",
-            "access_control_search"
-        ],
-        "name": ["idm_admins_acp_manage"],
-        "uuid": ["00000000-0000-0000-0000-ffffff000005"],
-        "description": ["Builtin IDM Administrators Access Controls to manage the install."],
-        "acp_enable": ["true"],
-        "acp_receiver": [
-            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000001\"]}"
-        ],
-        "acp_targetscope": [
-            "{\"And\": [{\"Pres\": \"class\"}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
-        ],
-        "acp_search_attr": ["name", "class", "uuid", "classname", "attributename", "memberof"],
-        "acp_modify_class": ["person"],
-        "acp_modify_removedattr": ["class", "displayname", "name", "description"],
-        "acp_modify_presentattr": ["class", "displayname", "name", "description"],
-        "acp_create_class": ["object", "person", "account"],
-        "acp_create_attr": ["name", "class", "description", "displayname"]
-    }
-}"#;
-*/
-
-pub static _UUID_IDM_ALL_ACP_READ_V1: &'static str = "00000000-0000-0000-0000-ffffff000006";
 pub static JSON_IDM_ALL_ACP_READ_V1: &'static str = r#"{
     "state": null,
     "attrs": {
@@ -518,7 +597,6 @@ pub static JSON_IDM_ALL_ACP_READ_V1: &'static str = r#"{
 }"#;
 
 // 7 people read acp JSON_IDM_PEOPLE_READ_PRIV_V1
-pub static _UUID_IDM_ACP_PEOPLE_READ_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000007";
 pub static JSON_IDM_ACP_PEOPLE_READ_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -542,8 +620,6 @@ pub static JSON_IDM_ACP_PEOPLE_READ_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 8 people write acp JSON_IDM_PEOPLE_WRITE_PRIV_V1
-pub static _UUID_IDM_ACP_PEOPLE_WRITE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000008";
 pub static JSON_IDM_ACP_PEOPLE_WRITE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -570,7 +646,6 @@ pub static JSON_IDM_ACP_PEOPLE_WRITE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 9 group write acp JSON_IDM_GROUP_WRITE_PRIV_V1
-pub static _UUID_IDM_ACP_GROUP_WRITE_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000009";
 pub static JSON_IDM_ACP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -601,8 +676,6 @@ pub static JSON_IDM_ACP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 10 account read acp JSON_IDM_ACCOUNT_READ_PRIV_V1
-pub static _UUID_IDM_ACP_ACCOUNT_READ_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000010";
 pub static JSON_IDM_ACP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -626,8 +699,6 @@ pub static JSON_IDM_ACP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 11 account write acp JSON_IDM_ACCOUNT_WRITE_PRIV_V1
-pub static _UUID_IDM_ACP_ACCOUNT_WRITE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000011";
 pub static JSON_IDM_ACP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -654,8 +725,6 @@ pub static JSON_IDM_ACP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 12 service account create acp (only admins?)  JSON_IDM_SERVICE_ACCOUNT_CREATE_PRIV_V1
-pub static _UUID_IDM_ACP_ACCOUNT_MANAGE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000012";
 pub static JSON_IDM_ACP_ACCOUNT_MANAGE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -688,8 +757,6 @@ pub static JSON_IDM_ACP_ACCOUNT_MANAGE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 13 user (person) account create acp  JSON_IDM_PERSON_ACCOUNT_CREATE_PRIV_V1
-pub static _UUID_IDM_ACP_PEOPLE_MANAGE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000013";
 pub static JSON_IDM_ACP_PEOPLE_MANAGE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -724,7 +791,6 @@ pub static JSON_IDM_ACP_PEOPLE_MANAGE_PRIV_V1: &'static str = r#"{
 }"#;
 
 // 14 radius read acp JSON_IDM_RADIUS_SERVERS_V1
-pub static _UUID_IDM_ACP_RADIUS_SERVERS_V1: &'static str = "00000000-0000-0000-0000-ffffff000014";
 // The targetscope of this could change later to a "radius access" group or similar so we can add/remove
 //  users from having radius access easier.
 pub static JSON_IDM_ACP_RADIUS_SERVERS_V1: &'static str = r#"{
@@ -750,8 +816,6 @@ pub static JSON_IDM_ACP_RADIUS_SERVERS_V1: &'static str = r#"{
     }
 }"#;
 // 15 high priv account read JSON_IDM_HP_ACCOUNT_READ_PRIV_V1
-pub static _UUID_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000015";
 pub static JSON_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -775,8 +839,6 @@ pub static JSON_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
     }
 }"#;
 // 16 high priv account write JSON_IDM_HP_ACCOUNT_WRITE_PRIV_V1
-pub static _UUID_IDM_ACP_HP_ACCOUNT_WRITE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000016";
 pub static JSON_IDM_ACP_HP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -804,8 +866,6 @@ pub static JSON_IDM_ACP_HP_ACCOUNT_WRITE_PRIV_V1: &'static str = r#"{
 }"#;
 
 // 17 high priv group write --> JSON_IDM_HP_GROUP_WRITE_PRIV_V1 (12)
-pub static _UUID_IDM_ACP_HP_GROUP_WRITE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000017";
 pub static JSON_IDM_ACP_HP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -837,8 +897,6 @@ pub static JSON_IDM_ACP_HP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
 }"#;
 
 // 18 schema write JSON_IDM_SCHEMA_WRITE_PRIV_V1
-pub static _UUID_IDM_ACP_SCHEMA_WRITE_ATTRS_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000018";
 pub static JSON_IDM_ACP_SCHEMA_WRITE_ATTRS_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -900,7 +958,6 @@ pub static JSON_IDM_ACP_SCHEMA_WRITE_ATTRS_PRIV_V1: &'static str = r#"{
 }"#;
 
 // 19 acp read/write
-pub static _UUID_IDM_ACP_ACP_MANAGE_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000019";
 pub static JSON_IDM_ACP_ACP_MANAGE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -994,8 +1051,6 @@ pub static JSON_IDM_ACP_ACP_MANAGE_PRIV_V1: &'static str = r#"{
     }
 }"#;
 
-pub static _UUID_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000020";
 pub static JSON_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -1055,8 +1110,6 @@ pub static JSON_IDM_ACP_SCHEMA_WRITE_CLASSES_PRIV_V1: &'static str = r#"{
 // 21 - anonymous / everyone schema read.
 
 // 22 - group create right
-pub static _UUID_IDM_ACP_GROUP_MANAGE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000022";
 pub static JSON_IDM_ACP_GROUP_MANAGE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -1088,8 +1141,6 @@ pub static JSON_IDM_ACP_GROUP_MANAGE_PRIV_V1: &'static str = r#"{
 }"#;
 
 // 23 - HP account manage
-pub static _UUID_IDM_ACP_HP_ACCOUNT_MANAGE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000023";
 pub static JSON_IDM_ACP_HP_ACCOUNT_MANAGE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -1123,8 +1174,6 @@ pub static JSON_IDM_ACP_HP_ACCOUNT_MANAGE_PRIV_V1: &'static str = r#"{
 }"#;
 
 // 24 - hp group manage
-pub static _UUID_IDM_ACP_HP_GROUP_MANAGE_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000024";
 pub static JSON_IDM_ACP_HP_GROUP_MANAGE_PRIV_V1: &'static str = r#"{
     "attrs": {
         "class": [
@@ -1168,62 +1217,8 @@ pub static JSON_ANONYMOUS_V1: &'static str = r#"{
 
 // Core
 // Schema uuids start at 00000000-0000-0000-0000-ffff00000000
-pub static UUID_SCHEMA_ATTR_CLASS: &'static str = "00000000-0000-0000-0000-ffff00000000";
-pub static UUID_SCHEMA_ATTR_UUID: &'static str = "00000000-0000-0000-0000-ffff00000001";
-pub static UUID_SCHEMA_ATTR_NAME: &'static str = "00000000-0000-0000-0000-ffff00000002";
-pub static UUID_SCHEMA_ATTR_ATTRIBUTENAME: &'static str = "00000000-0000-0000-0000-ffff00000048";
-pub static UUID_SCHEMA_ATTR_CLASSNAME: &'static str = "00000000-0000-0000-0000-ffff00000049";
-pub static UUID_SCHEMA_ATTR_PRINCIPAL_NAME: &'static str = "00000000-0000-0000-0000-ffff00000003";
-pub static UUID_SCHEMA_ATTR_DESCRIPTION: &'static str = "00000000-0000-0000-0000-ffff00000004";
-pub static UUID_SCHEMA_ATTR_MULTIVALUE: &'static str = "00000000-0000-0000-0000-ffff00000005";
-pub static UUID_SCHEMA_ATTR_UNIQUE: &'static str = "00000000-0000-0000-0000-ffff00000047";
-pub static UUID_SCHEMA_ATTR_INDEX: &'static str = "00000000-0000-0000-0000-ffff00000006";
-pub static UUID_SCHEMA_ATTR_SYNTAX: &'static str = "00000000-0000-0000-0000-ffff00000007";
-pub static UUID_SCHEMA_ATTR_SYSTEMMAY: &'static str = "00000000-0000-0000-0000-ffff00000008";
-pub static UUID_SCHEMA_ATTR_MAY: &'static str = "00000000-0000-0000-0000-ffff00000009";
-pub static UUID_SCHEMA_ATTR_SYSTEMMUST: &'static str = "00000000-0000-0000-0000-ffff00000010";
-pub static UUID_SCHEMA_ATTR_MUST: &'static str = "00000000-0000-0000-0000-ffff00000011";
-pub static UUID_SCHEMA_ATTR_MEMBEROF: &'static str = "00000000-0000-0000-0000-ffff00000012";
-pub static UUID_SCHEMA_ATTR_MEMBER: &'static str = "00000000-0000-0000-0000-ffff00000013";
-pub static UUID_SCHEMA_ATTR_DIRECTMEMBEROF: &'static str = "00000000-0000-0000-0000-ffff00000014";
-pub static UUID_SCHEMA_ATTR_VERSION: &'static str = "00000000-0000-0000-0000-ffff00000015";
-pub static UUID_SCHEMA_ATTR_DOMAIN: &'static str = "00000000-0000-0000-0000-ffff00000016";
-pub static UUID_SCHEMA_ATTR_ACP_ENABLE: &'static str = "00000000-0000-0000-0000-ffff00000017";
-pub static UUID_SCHEMA_ATTR_ACP_RECEIVER: &'static str = "00000000-0000-0000-0000-ffff00000018";
-pub static UUID_SCHEMA_ATTR_ACP_TARGETSCOPE: &'static str = "00000000-0000-0000-0000-ffff00000019";
-pub static UUID_SCHEMA_ATTR_ACP_SEARCH_ATTR: &'static str = "00000000-0000-0000-0000-ffff00000020";
-pub static UUID_SCHEMA_ATTR_ACP_CREATE_CLASS: &'static str = "00000000-0000-0000-0000-ffff00000021";
-pub static UUID_SCHEMA_ATTR_ACP_CREATE_ATTR: &'static str = "00000000-0000-0000-0000-ffff00000022";
-pub static UUID_SCHEMA_ATTR_ACP_MODIFY_REMOVEDATTR: &'static str =
-    "00000000-0000-0000-0000-ffff00000023";
-pub static UUID_SCHEMA_ATTR_ACP_MODIFY_PRESENTATTR: &'static str =
-    "00000000-0000-0000-0000-ffff00000024";
-pub static UUID_SCHEMA_ATTR_ACP_MODIFY_CLASS: &'static str = "00000000-0000-0000-0000-ffff00000025";
-
-pub static UUID_SCHEMA_CLASS_ATTRIBUTETYPE: &'static str = "00000000-0000-0000-0000-ffff00000026";
-pub static UUID_SCHEMA_CLASS_CLASSTYPE: &'static str = "00000000-0000-0000-0000-ffff00000027";
-pub static UUID_SCHEMA_CLASS_OBJECT: &'static str = "00000000-0000-0000-0000-ffff00000028";
-pub static UUID_SCHEMA_CLASS_EXTENSIBLEOBJECT: &'static str =
-    "00000000-0000-0000-0000-ffff00000029";
-pub static UUID_SCHEMA_CLASS_MEMBEROF: &'static str = "00000000-0000-0000-0000-ffff00000030";
-
-pub static UUID_SCHEMA_CLASS_RECYCLED: &'static str = "00000000-0000-0000-0000-ffff00000031";
-pub static UUID_SCHEMA_CLASS_TOMBSTONE: &'static str = "00000000-0000-0000-0000-ffff00000032";
-pub static UUID_SCHEMA_CLASS_SYSTEM_INFO: &'static str = "00000000-0000-0000-0000-ffff00000033";
-pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_PROFILE: &'static str =
-    "00000000-0000-0000-0000-ffff00000034";
-pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_SEARCH: &'static str =
-    "00000000-0000-0000-0000-ffff00000035";
-pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_DELETE: &'static str =
-    "00000000-0000-0000-0000-ffff00000036";
-pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_MODIFY: &'static str =
-    "00000000-0000-0000-0000-ffff00000037";
-pub static UUID_SCHEMA_CLASS_ACCESS_CONTROL_CREATE: &'static str =
-    "00000000-0000-0000-0000-ffff00000038";
-pub static UUID_SCHEMA_CLASS_SYSTEM: &'static str = "00000000-0000-0000-0000-ffff00000039";
 
 // system supplementary
-pub static UUID_SCHEMA_ATTR_DISPLAYNAME: &'static str = "00000000-0000-0000-0000-ffff00000040";
 pub static JSON_SCHEMA_ATTR_DISPLAYNAME: &'static str = r#"{
     "valid": {
       "uuid": "00000000-0000-0000-0000-ffff00000040"
@@ -1258,7 +1253,6 @@ pub static JSON_SCHEMA_ATTR_DISPLAYNAME: &'static str = r#"{
       ]
     }
 }"#;
-pub static UUID_SCHEMA_ATTR_MAIL: &'static str = "00000000-0000-0000-0000-ffff00000041";
 pub static JSON_SCHEMA_ATTR_MAIL: &'static str = r#"
   {
     "valid": {
@@ -1295,7 +1289,6 @@ pub static JSON_SCHEMA_ATTR_MAIL: &'static str = r#"
     }
   }
 "#;
-pub static UUID_SCHEMA_ATTR_SSH_PUBLICKEY: &'static str = "00000000-0000-0000-0000-ffff00000042";
 pub static JSON_SCHEMA_ATTR_SSH_PUBLICKEY: &'static str = r#"
   {
     "valid": {
@@ -1330,8 +1323,6 @@ pub static JSON_SCHEMA_ATTR_SSH_PUBLICKEY: &'static str = r#"
     }
   }
 "#;
-pub static UUID_SCHEMA_ATTR_PRIMARY_CREDENTIAL: &'static str =
-    "00000000-0000-0000-0000-ffff00000043";
 pub static JSON_SCHEMA_ATTR_PRIMARY_CREDENTIAL: &'static str = r#"
   {
     "valid": {
@@ -1366,7 +1357,6 @@ pub static JSON_SCHEMA_ATTR_PRIMARY_CREDENTIAL: &'static str = r#"
     }
   }
 "#;
-pub static UUID_SCHEMA_ATTR_LEGALNAME: &'static str = "00000000-0000-0000-0000-ffff00000050";
 pub static JSON_SCHEMA_ATTR_LEGALNAME: &'static str = r#"{
     "attrs": {
       "class": [
@@ -1397,7 +1387,6 @@ pub static JSON_SCHEMA_ATTR_LEGALNAME: &'static str = r#"{
       ]
     }
 }"#;
-pub static UUID_SCHEMA_ATTR_RADIUS_SECRET: &'static str = "00000000-0000-0000-0000-ffff00000051";
 pub static JSON_SCHEMA_ATTR_RADIUS_SECRET: &'static str = r#"{
     "attrs": {
       "class": [
@@ -1427,7 +1416,6 @@ pub static JSON_SCHEMA_ATTR_RADIUS_SECRET: &'static str = r#"{
     }
 }"#;
 
-pub static UUID_SCHEMA_ATTR_DOMAIN_NAME: &'static str = "00000000-0000-0000-0000-ffff00000053";
 pub static JSON_SCHEMA_ATTR_DOMAIN_NAME: &'static str = r#"{
     "attrs": {
       "class": [
@@ -1458,7 +1446,6 @@ pub static JSON_SCHEMA_ATTR_DOMAIN_NAME: &'static str = r#"{
       ]
     }
 }"#;
-pub static UUID_SCHEMA_ATTR_DOMAIN_UUID: &'static str = "00000000-0000-0000-0000-ffff00000054";
 pub static JSON_SCHEMA_ATTR_DOMAIN_UUID: &'static str = r#"{
     "attrs": {
       "class": [
@@ -1489,7 +1476,6 @@ pub static JSON_SCHEMA_ATTR_DOMAIN_UUID: &'static str = r#"{
       ]
     }
 }"#;
-pub static UUID_SCHEMA_ATTR_DOMAIN_SSID: &'static str = "00000000-0000-0000-0000-ffff00000055";
 pub static JSON_SCHEMA_ATTR_DOMAIN_SSID: &'static str = r#"{
     "attrs": {
       "class": [
@@ -1519,7 +1505,6 @@ pub static JSON_SCHEMA_ATTR_DOMAIN_SSID: &'static str = r#"{
     }
 }"#;
 
-pub static UUID_SCHEMA_CLASS_PERSON: &'static str = "00000000-0000-0000-0000-ffff00000044";
 pub static JSON_SCHEMA_CLASS_PERSON: &'static str = r#"
   {
     "valid": {
@@ -1553,7 +1538,6 @@ pub static JSON_SCHEMA_CLASS_PERSON: &'static str = r#"
   }
 "#;
 
-pub static UUID_SCHEMA_CLASS_GROUP: &'static str = "00000000-0000-0000-0000-ffff00000045";
 pub static JSON_SCHEMA_CLASS_GROUP: &'static str = r#"
   {
     "valid": {
@@ -1584,7 +1568,6 @@ pub static JSON_SCHEMA_CLASS_GROUP: &'static str = r#"
     }
   }
 "#;
-pub static UUID_SCHEMA_CLASS_ACCOUNT: &'static str = "00000000-0000-0000-0000-ffff00000046";
 pub static JSON_SCHEMA_CLASS_ACCOUNT: &'static str = r#"
   {
     "attrs": {
@@ -1620,15 +1603,6 @@ pub static JSON_SCHEMA_CLASS_ACCOUNT: &'static str = r#"
 //  domain_name <- should be the dns name?
 //  domain_ssid <- for radius
 //
-pub static UUID_SCHEMA_CLASS_DOMAIN_INFO: &'static str = "00000000-0000-0000-0000-ffff00000052";
-// Why is domain_uuid may? During str -> entry we do a schema check in the migration
-// and the domain_uuid doesn't exist yet. It's generated. As a result this would
-// fail. There are good reasons to keep the schema check there early in the
-// migration, to keep things sane. Moving this to may is in a way, wrong. Domain
-// uuid is required. But the create will always put it there, and it's system
-// protected so it can't be removed. Finally, if removed, we'll just error
-// and say it's corrupted, so there are multiple defences here, and someone
-// really needs to be malicious to do this.
 pub static JSON_SCHEMA_CLASS_DOMAIN_INFO: &'static str = r#"
   {
     "attrs": {
@@ -1644,11 +1618,11 @@ pub static JSON_SCHEMA_CLASS_DOMAIN_INFO: &'static str = r#"
         "domain_info"
       ],
       "systemmay": [
-        "domain_uuid",
         "domain_ssid"
       ],
       "systemmust": [
         "name",
+        "domain_uuid",
         "domain_name"
       ],
       "uuid": [

--- a/kanidmd/src/lib/constants.rs
+++ b/kanidmd/src/lib/constants.rs
@@ -41,7 +41,7 @@ pub static _UUID_IDM_HIGH_PRIVILEGE: &'static str = "00000000-0000-0000-0000-000
 pub static UUID_SCHEMA_ATTR_CLASS: &'static str = "00000000-0000-0000-0000-ffff00000000";
 pub static UUID_SCHEMA_ATTR_UUID: &'static str = "00000000-0000-0000-0000-ffff00000001";
 pub static UUID_SCHEMA_ATTR_NAME: &'static str = "00000000-0000-0000-0000-ffff00000002";
-pub static UUID_SCHEMA_ATTR_PRINCIPAL_NAME: &'static str = "00000000-0000-0000-0000-ffff00000003";
+pub static UUID_SCHEMA_ATTR_SPN: &'static str = "00000000-0000-0000-0000-ffff00000003";
 pub static UUID_SCHEMA_ATTR_DESCRIPTION: &'static str = "00000000-0000-0000-0000-ffff00000004";
 pub static UUID_SCHEMA_ATTR_MULTIVALUE: &'static str = "00000000-0000-0000-0000-ffff00000005";
 pub static UUID_SCHEMA_ATTR_UNIQUE: &'static str = "00000000-0000-0000-0000-ffff00000047";
@@ -552,6 +552,7 @@ pub static JSON_IDM_SELF_ACP_READ_V1: &'static str = r#"{
         ],
         "acp_search_attr": [
             "name",
+            "spn",
             "displayname",
             "legalname",
             "class",
@@ -601,6 +602,7 @@ pub static JSON_IDM_ALL_ACP_READ_V1: &'static str = r#"{
         ],
         "acp_search_attr": [
             "name",
+            "spn",
             "displayname",
             "class",
             "memberof",
@@ -680,7 +682,7 @@ pub static JSON_IDM_ACP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
             "{\"And\": [{\"Eq\": [\"class\",\"group\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"memberof\",\"00000000-0000-0000-0000-000000001000\"]}, {\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
         ],
         "acp_search_attr": [
-            "class", "name", "uuid", "description", "member"
+            "class", "name", "spn", "uuid", "description", "member"
         ],
         "acp_modify_removedattr": [
             "name", "description", "member"
@@ -709,7 +711,7 @@ pub static JSON_IDM_ACP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
             "{\"And\": [{\"Eq\": [\"class\",\"account\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"memberof\",\"00000000-0000-0000-0000-000000001000\"]}, {\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
         ],
         "acp_search_attr": [
-            "class", "name", "uuid", "displayname", "ssh_publickey", "primary_credential", "memberof", "mail"
+            "class", "name", "spn", "uuid", "displayname", "ssh_publickey", "primary_credential", "memberof", "mail"
         ]
     }
 }"#;
@@ -826,7 +828,7 @@ pub static JSON_IDM_ACP_RADIUS_SERVERS_V1: &'static str = r#"{
             "{\"And\": [{\"Pres\": \"class\"}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
         ],
         "acp_search_attr": [
-            "name", "uuid", "radius_secret"
+            "name", "spn", "uuid", "radius_secret"
         ]
     }
 }"#;
@@ -849,7 +851,7 @@ pub static JSON_IDM_ACP_HP_ACCOUNT_READ_PRIV_V1: &'static str = r#"{
             "{\"And\": [{\"Eq\": [\"class\",\"account\"]}, {\"Eq\": [\"memberof\",\"00000000-0000-0000-0000-000000001000\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
         ],
         "acp_search_attr": [
-            "class", "name", "uuid", "displayname", "ssh_publickey", "primary_credential", "memberof"
+            "class", "name", "spn", "uuid", "displayname", "ssh_publickey", "primary_credential", "memberof"
         ]
     }
 }"#;
@@ -1610,7 +1612,8 @@ pub static JSON_SCHEMA_CLASS_GROUP: &'static str = r#"
         "member"
       ],
       "systemmust": [
-        "name"
+        "name",
+        "spn"
       ],
       "uuid": [
         "00000000-0000-0000-0000-ffff00000045"
@@ -1639,7 +1642,8 @@ pub static JSON_SCHEMA_CLASS_ACCOUNT: &'static str = r#"
       ],
       "systemmust": [
         "displayname",
-        "name"
+        "name",
+        "spn"
       ],
       "uuid": [
         "00000000-0000-0000-0000-ffff00000046"

--- a/kanidmd/src/lib/constants.rs
+++ b/kanidmd/src/lib/constants.rs
@@ -149,8 +149,7 @@ pub static _UUID_IDM_ACP_HP_ACCOUNT_MANAGE_PRIV_V1: &'static str =
 pub static _UUID_IDM_ACP_HP_GROUP_MANAGE_PRIV_V1: &'static str =
     "00000000-0000-0000-0000-ffffff000024";
 // Skip 25 - see domain info.
-pub static UUID_IDM_ACP_DOMAIN_ADMIN_PRIV_V1: &'static str =
-    "00000000-0000-0000-0000-ffffff000026";
+pub static UUID_IDM_ACP_DOMAIN_ADMIN_PRIV_V1: &'static str = "00000000-0000-0000-0000-ffffff000026";
 
 // End of system ranges
 pub static STR_UUID_DOES_NOT_EXIST: &'static str = "00000000-0000-0000-0000-fffffffffffe";
@@ -1254,7 +1253,6 @@ pub static JSON_IDM_ACP_DOMAIN_ADMIN_PRIV_V1: &'static str = r#"{
         ]
     }
 }"#;
-
 
 // Anonymous should be the last opbject in the range here.
 pub static JSON_ANONYMOUS_V1: &'static str = r#"{

--- a/kanidmd/src/lib/constants.rs
+++ b/kanidmd/src/lib/constants.rs
@@ -32,6 +32,8 @@ pub static _UUID_IDM_HP_ACCOUNT_MANAGE_PRIV: &'static str = "00000000-0000-0000-
 pub static _UUID_IDM_HP_GROUP_MANAGE_PRIV: &'static str = "00000000-0000-0000-0000-000000000017";
 pub static _UUID_IDM_ADMIN_V1: &'static str = "00000000-0000-0000-0000-000000000018";
 pub static _UUID_SYSTEM_ADMINS: &'static str = "00000000-0000-0000-0000-000000000019";
+// TODO
+pub static UUID_DOMAIN_ADMINS: &'static str = "00000000-0000-0000-0000-000000000020";
 //
 pub static _UUID_IDM_HIGH_PRIVILEGE: &'static str = "00000000-0000-0000-0000-000000001000";
 
@@ -106,7 +108,7 @@ pub static UUID_SCHEMA_ATTR_DOMAIN_SSID: &'static str = "00000000-0000-0000-0000
 // System and domain infos
 // I'd like to strongly criticise william of the past for fucking up these allocations.
 pub static _UUID_SYSTEM_INFO: &'static str = "00000000-0000-0000-0000-ffffff000001";
-pub static _UUID_DOMAIN_INFO: &'static str = "00000000-0000-0000-0000-ffffff000025";
+pub static UUID_DOMAIN_INFO: &'static str = "00000000-0000-0000-0000-ffffff000025";
 
 // Access controls
 // skip 00 / 01 - see system info
@@ -147,6 +149,8 @@ pub static _UUID_IDM_ACP_HP_ACCOUNT_MANAGE_PRIV_V1: &'static str =
 pub static _UUID_IDM_ACP_HP_GROUP_MANAGE_PRIV_V1: &'static str =
     "00000000-0000-0000-0000-ffffff000024";
 // Skip 25 - see domain info.
+pub static UUID_IDM_ACP_DOMAIN_ADMIN_PRIV_V1: &'static str =
+    "00000000-0000-0000-0000-ffffff000026";
 
 // End of system ranges
 pub static STR_UUID_DOES_NOT_EXIST: &'static str = "00000000-0000-0000-0000-fffffffffffe";
@@ -391,6 +395,17 @@ pub static JSON_IDM_HP_GROUP_WRITE_PRIV_V1: &'static str = r#"{
         ]
     }
 }"#;
+pub static JSON_DOMAIN_ADMINS: &'static str = r#"{
+    "attrs": {
+        "class": ["group", "object"],
+        "name": ["domain_admins"],
+        "uuid": ["00000000-0000-0000-0000-000000000020"],
+        "description": ["Builtin IDM Group for granting local domain administration rights and trust administration rights."],
+        "member": [
+            "00000000-0000-0000-0000-000000000000"
+        ]
+    }
+}"#;
 
 // This must be the last group to init to include the UUID of the other high priv groups.
 pub static JSON_IDM_HIGH_PRIVILEGE_V1: &'static str = r#"{
@@ -418,6 +433,7 @@ pub static JSON_IDM_HIGH_PRIVILEGE_V1: &'static str = r#"{
             "00000000-0000-0000-0000-000000000016",
             "00000000-0000-0000-0000-000000000017",
             "00000000-0000-0000-0000-000000000019",
+            "00000000-0000-0000-0000-000000000020",
             "00000000-0000-0000-0000-000000001000"
         ]
     }
@@ -1203,6 +1219,42 @@ pub static JSON_IDM_ACP_HP_GROUP_MANAGE_PRIV_V1: &'static str = r#"{
         ]
     }
 }"#;
+
+// 25 - domain admins acp
+pub static JSON_IDM_ACP_DOMAIN_ADMIN_PRIV_V1: &'static str = r#"{
+    "attrs": {
+        "class": [
+            "object",
+            "access_control_profile",
+            "access_control_search",
+            "access_control_modify"
+        ],
+        "name": ["idm_acp_domain_admin_priv"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000026"],
+        "description": ["Builtin IDM Control for granting domain info administration locally"],
+        "acp_enable": ["true"],
+        "acp_receiver": [
+            "{\"Eq\":[\"memberof\",\"00000000-0000-0000-0000-000000000020\"]}"
+        ],
+        "acp_targetscope": [
+            "{\"And\": [{\"Eq\": [\"uuid\",\"00000000-0000-0000-0000-ffffff000025\"]}, {\"AndNot\": {\"Or\": [{\"Eq\": [\"class\", \"tombstone\"]}, {\"Eq\": [\"class\", \"recycled\"]}]}}]}"
+        ],
+        "acp_search_attr": [
+            "name",
+            "uuid",
+            "domain_name",
+            "domain_ssid",
+            "domain_uuid"
+        ],
+        "acp_modify_removedattr": [
+            "domain_ssid"
+        ],
+        "acp_modify_presentattr": [
+            "domain_ssid"
+        ]
+    }
+}"#;
+
 
 // Anonymous should be the last opbject in the range here.
 pub static JSON_ANONYMOUS_V1: &'static str = r#"{

--- a/kanidmd/src/lib/constants.rs
+++ b/kanidmd/src/lib/constants.rs
@@ -1,5 +1,7 @@
 use uuid::Uuid;
 
+// Increment this as we add new schema types and values!!!
+pub static SYSTEM_INDEX_VERSION: i64 = 3;
 // On test builds, define to 60 seconds
 #[cfg(test)]
 pub static PURGE_TIMEOUT: u64 = 60;
@@ -305,11 +307,21 @@ pub static JSON_IDM_HIGH_PRIVILEGE_V1: &'static str = r#"{
 pub static _UUID_SYSTEM_INFO: &'static str = "00000000-0000-0000-0000-ffffff000001";
 pub static JSON_SYSTEM_INFO_V1: &'static str = r#"{
     "attrs": {
-        "class": ["object", "system_info"],
+        "class": ["object", "system_info", "system"],
         "uuid": ["00000000-0000-0000-0000-ffffff000001"],
         "description": ["System info and metadata object."],
-        "version": ["1"],
-        "domain": ["example.com"]
+        "version": ["2"]
+    }
+}"#;
+
+pub static _UUID_DOMAIN_INFO: &'static str = "00000000-0000-0000-0000-ffffff000025";
+pub static JSON_DOMAIN_INFO_V1: &'static str = r#"{
+    "attrs": {
+        "class": ["object", "domain_info", "system"],
+        "name": ["domain_local"],
+        "uuid": ["00000000-0000-0000-0000-ffffff000025"],
+        "description": ["This local domain's info and metadata object."],
+        "domain_name": ["example.com"]
     }
 }"#;
 
@@ -1415,6 +1427,98 @@ pub static JSON_SCHEMA_ATTR_RADIUS_SECRET: &'static str = r#"{
     }
 }"#;
 
+pub static UUID_SCHEMA_ATTR_DOMAIN_NAME: &'static str = "00000000-0000-0000-0000-ffff00000053";
+pub static JSON_SCHEMA_ATTR_DOMAIN_NAME: &'static str = r#"{
+    "attrs": {
+      "class": [
+        "object",
+        "system",
+        "attributetype"
+      ],
+      "description": [
+        "The domain's DNS name for webauthn and SPN generation purposes."
+      ],
+      "index": [
+        "EQUALITY"
+      ],
+      "unique": [
+        "true"
+      ],
+      "multivalue": [
+        "false"
+      ],
+      "attributename": [
+        "domain_name"
+      ],
+      "syntax": [
+        "UTF8STRING_INSENSITIVE"
+      ],
+      "uuid": [
+        "00000000-0000-0000-0000-ffff00000053"
+      ]
+    }
+}"#;
+pub static UUID_SCHEMA_ATTR_DOMAIN_UUID: &'static str = "00000000-0000-0000-0000-ffff00000054";
+pub static JSON_SCHEMA_ATTR_DOMAIN_UUID: &'static str = r#"{
+    "attrs": {
+      "class": [
+        "object",
+        "system",
+        "attributetype"
+      ],
+      "description": [
+        "The domain's uuid, used in CSN and trust relationships."
+      ],
+      "index": [
+        "EQUALITY"
+      ],
+      "unique": [
+        "true"
+      ],
+      "multivalue": [
+        "false"
+      ],
+      "attributename": [
+        "domain_uuid"
+      ],
+      "syntax": [
+        "UUID"
+      ],
+      "uuid": [
+        "00000000-0000-0000-0000-ffff00000054"
+      ]
+    }
+}"#;
+pub static UUID_SCHEMA_ATTR_DOMAIN_SSID: &'static str = "00000000-0000-0000-0000-ffff00000055";
+pub static JSON_SCHEMA_ATTR_DOMAIN_SSID: &'static str = r#"{
+    "attrs": {
+      "class": [
+        "object",
+        "system",
+        "attributetype"
+      ],
+      "description": [
+        "The domains site-wide SSID for device autoconfiguration of wireless"
+      ],
+      "index": [],
+      "unique": [
+        "true"
+      ],
+      "multivalue": [
+        "false"
+      ],
+      "attributename": [
+        "domain_ssid"
+      ],
+      "syntax": [
+        "UTF8STRING"
+      ],
+      "uuid": [
+        "00000000-0000-0000-0000-ffff00000055"
+      ]
+    }
+}"#;
+
 pub static UUID_SCHEMA_CLASS_PERSON: &'static str = "00000000-0000-0000-0000-ffff00000044";
 pub static JSON_SCHEMA_CLASS_PERSON: &'static str = r#"
   {
@@ -1510,6 +1614,52 @@ pub static JSON_SCHEMA_CLASS_ACCOUNT: &'static str = r#"
     }
   }
 "#;
+
+// domain_info type
+//  domain_uuid
+//  domain_name <- should be the dns name?
+//  domain_ssid <- for radius
+//
+pub static UUID_SCHEMA_CLASS_DOMAIN_INFO: &'static str = "00000000-0000-0000-0000-ffff00000052";
+// Why is domain_uuid may? During str -> entry we do a schema check in the migration
+// and the domain_uuid doesn't exist yet. It's generated. As a result this would
+// fail. There are good reasons to keep the schema check there early in the
+// migration, to keep things sane. Moving this to may is in a way, wrong. Domain
+// uuid is required. But the create will always put it there, and it's system
+// protected so it can't be removed. Finally, if removed, we'll just error
+// and say it's corrupted, so there are multiple defences here, and someone
+// really needs to be malicious to do this.
+pub static JSON_SCHEMA_CLASS_DOMAIN_INFO: &'static str = r#"
+  {
+    "attrs": {
+      "class": [
+        "object",
+        "system",
+        "classtype"
+      ],
+      "description": [
+        "Local domain information and partial configuration."
+      ],
+      "classname": [
+        "domain_info"
+      ],
+      "systemmay": [
+        "domain_uuid",
+        "domain_ssid"
+      ],
+      "systemmust": [
+        "name",
+        "domain_name"
+      ],
+      "uuid": [
+        "00000000-0000-0000-0000-ffff00000052"
+      ]
+    }
+  }
+"#;
+
+// need a domain_trust_info as well.
+// TODO
 
 // ============ TEST DATA ============
 #[cfg(test)]

--- a/kanidmd/src/lib/core.rs
+++ b/kanidmd/src/lib/core.rs
@@ -975,6 +975,42 @@ fn group_id_delete(
     json_rest_event_delete_id(path, req, state, filter)
 }
 
+fn domain_get(
+    (req, state): (HttpRequest<AppState>, State<AppState>),
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let filter = filter_all!(f_eq("class", PartialValue::new_class("domain_info")));
+    json_rest_event_get(req, state, filter, None)
+}
+
+fn domain_id_get(
+    (path, req, state): (Path<String>, HttpRequest<AppState>, State<AppState>),
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let filter = filter_all!(f_eq("class", PartialValue::new_class("domain_info")));
+    json_rest_event_get_id(path, req, state, filter, None)
+}
+
+fn domain_id_get_attr(
+    (path, req, state): (
+        Path<(String, String)>,
+        HttpRequest<AppState>,
+        State<AppState>,
+    ),
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let filter = filter_all!(f_eq("class", PartialValue::new_class("domain_info")));
+    json_rest_event_get_id_attr(path, req, state, filter)
+}
+
+fn domain_id_put_attr(
+    (path, req, state): (
+        Path<(String, String)>,
+        HttpRequest<AppState>,
+        State<AppState>,
+    ),
+) -> impl Future<Item = HttpResponse, Error = Error> {
+    let filter = filter_all!(f_eq("class", PartialValue::new_class("domain_info")));
+    json_rest_event_put_id_attr(path, req, state, filter)
+}
+
 fn do_nothing((_req, _state): (HttpRequest<AppState>, State<AppState>)) -> String {
     "did nothing".to_string()
 }
@@ -1700,6 +1736,17 @@ pub fn create_server_core(config: Configuration) {
         })
         // Claims
         // TBD
+        // Domain
+        .resource("/v1/domain", |r| {
+            r.method(http::Method::GET).with_async(domain_get);
+        })
+        .resource("/v1/domain/{id}", |r| {
+            r.method(http::Method::GET).with_async(domain_id_get);
+        })
+        .resource("/v1/domain/{id}/_attr/{attr}", |r| {
+            r.method(http::Method::GET).with_async(domain_id_get_attr);
+            r.method(http::Method::PUT).with_async(domain_id_put_attr);
+        })
         // Recycle Bin
         .resource("/v1/recycle_bin", |r| {
             r.method(http::Method::GET).with(do_nothing)

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -1037,89 +1037,6 @@ impl<STATE> Entry<EntryValid, STATE> {
         &self.valid.uuid
     }
 
-    pub fn filter_from_attrs(&self, attrs: &Vec<String>) -> Option<Filter<FilterInvalid>> {
-        // Because we are a valid entry, a filter we create still may not
-        // be valid because the internal server entry templates are still
-        // created by humans! Plus double checking something already valid
-        // is not bad ...
-        //
-        // Generate a filter from the attributes requested and defined.
-        // Basically, this is a series of nested and's (which will be
-        // optimised down later: but if someone wants to solve flatten() ...)
-
-        // Take name: (a, b), name: (c, d) -> (name, a), (name, b), (name, c), (name, d)
-
-        let mut pairs: Vec<(&str, &Value)> = Vec::new();
-
-        for attr in attrs {
-            match self.attrs.get(attr) {
-                Some(values) => {
-                    for v in values {
-                        pairs.push((attr, v))
-                    }
-                }
-                None => return None,
-            }
-        }
-
-        Some(filter_all!(f_and(
-            pairs
-                .into_iter()
-                .map(|(attr, value)| {
-                    // We use FC directly here instead of f_eq to avoid an excess clone.
-                    FC::Eq(attr, value.to_partialvalue())
-                })
-                .collect()
-        )))
-    }
-
-    pub fn gen_modlist_assert(
-        &self,
-        schema: &dyn SchemaTransaction,
-    ) -> Result<ModifyList<ModifyInvalid>, SchemaError> {
-        // Create a modlist from this entry. We make this assuming we want the entry
-        // to have this one as a subset of values. This means if we have single
-        // values, we'll replace, if they are multivalue, we present them.
-        let mut mods = ModifyList::new();
-
-        for (k, vs) in self.attrs.iter() {
-            // WHY?! We skip uuid here because it is INVALID for a UUID
-            // to be in a modlist, and the base.rs plugin will fail if it
-            // is there. This actually doesn't matter, because to apply the
-            // modlist in these situations we already know the entry MUST
-            // exist with that UUID, we only need to conform it's other
-            // attributes into the same state.
-            //
-            // In the future, if we make uuid a real entry type, then this
-            // check can "go away" because uuid will never exist as an ava.
-            //
-            // NOTE: Remove this check when uuid becomes a real attribute.
-            // UUID is now a real attribute, but it also has an ava for db_entry
-            // conversion - so what do? If we remove it here, we could have CSN issue with
-            // repl on uuid conflict, but it probably shouldn't be an ava either ...
-            // as a result, I think we need to keep this continue line to not cause issues.
-            if k == "uuid" {
-                continue;
-            }
-            // Get the schema attribute type out.
-            match schema.is_multivalue(k) {
-                Ok(r) => {
-                    if !r {
-                        // As this is single value, purge then present to maintain this
-                        // invariant
-                        mods.push_mod(Modify::Purged(k.clone()));
-                    }
-                }
-                // A schema error happened, fail the whole operation.
-                Err(e) => return Err(e),
-            }
-            for v in vs {
-                mods.push_mod(Modify::Present(k.clone(), v.clone()));
-            }
-        }
-
-        Ok(mods)
-    }
 }
 
 impl Entry<EntryReduced, EntryCommitted> {
@@ -1441,6 +1358,90 @@ impl<VALID, STATE> Entry<VALID, STATE> {
             }),
             FilterResolved::AndNot(f) => !self.entry_match_no_index_inner(f),
         }
+    }
+
+    pub fn filter_from_attrs(&self, attrs: &Vec<String>) -> Option<Filter<FilterInvalid>> {
+        // Because we are a valid entry, a filter we create still may not
+        // be valid because the internal server entry templates are still
+        // created by humans! Plus double checking something already valid
+        // is not bad ...
+        //
+        // Generate a filter from the attributes requested and defined.
+        // Basically, this is a series of nested and's (which will be
+        // optimised down later: but if someone wants to solve flatten() ...)
+
+        // Take name: (a, b), name: (c, d) -> (name, a), (name, b), (name, c), (name, d)
+
+        let mut pairs: Vec<(&str, &Value)> = Vec::new();
+
+        for attr in attrs {
+            match self.attrs.get(attr) {
+                Some(values) => {
+                    for v in values {
+                        pairs.push((attr, v))
+                    }
+                }
+                None => return None,
+            }
+        }
+
+        Some(filter_all!(f_and(
+            pairs
+                .into_iter()
+                .map(|(attr, value)| {
+                    // We use FC directly here instead of f_eq to avoid an excess clone.
+                    FC::Eq(attr, value.to_partialvalue())
+                })
+                .collect()
+        )))
+    }
+
+    pub fn gen_modlist_assert(
+        &self,
+        schema: &dyn SchemaTransaction,
+    ) -> Result<ModifyList<ModifyInvalid>, SchemaError> {
+        // Create a modlist from this entry. We make this assuming we want the entry
+        // to have this one as a subset of values. This means if we have single
+        // values, we'll replace, if they are multivalue, we present them.
+        let mut mods = ModifyList::new();
+
+        for (k, vs) in self.attrs.iter() {
+            // WHY?! We skip uuid here because it is INVALID for a UUID
+            // to be in a modlist, and the base.rs plugin will fail if it
+            // is there. This actually doesn't matter, because to apply the
+            // modlist in these situations we already know the entry MUST
+            // exist with that UUID, we only need to conform it's other
+            // attributes into the same state.
+            //
+            // In the future, if we make uuid a real entry type, then this
+            // check can "go away" because uuid will never exist as an ava.
+            //
+            // NOTE: Remove this check when uuid becomes a real attribute.
+            // UUID is now a real attribute, but it also has an ava for db_entry
+            // conversion - so what do? If we remove it here, we could have CSN issue with
+            // repl on uuid conflict, but it probably shouldn't be an ava either ...
+            // as a result, I think we need to keep this continue line to not cause issues.
+            if k == "uuid" {
+                continue;
+            }
+            // Get the schema attribute type out.
+            match schema.is_multivalue(k) {
+                Ok(r) => {
+                    if !r {
+                        // As this is single value, purge then present to maintain this
+                        // invariant
+                        mods.push_mod(Modify::Purged(k.clone()));
+                    }
+                }
+                // A schema error happened, fail the whole operation.
+                Err(e) => return Err(e),
+            }
+            for v in vs {
+                mods.push_mod(Modify::Present(k.clone(), v.clone()));
+            }
+        }
+
+        Ok(mods)
     }
 }
 

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -259,7 +259,7 @@ impl Entry<EntryInvalid, EntryNew> {
             .map(|(k, vs)| {
                 let attr = k.to_lowercase();
                 let vv: BTreeSet<Value> = match attr.as_str() {
-                    "name" | "attributename" | "classname" | "version" | "domain" => {
+                    "name" | "attributename" | "classname" | "version" | "domain" | "domain_name" => {
                         vs.into_iter().map(|v| Value::new_iutf8(v)).collect()
                     }
                     "userid" | "uidnumber" => {
@@ -274,7 +274,7 @@ impl Entry<EntryInvalid, EntryNew> {
                     => {
                         vs.into_iter().map(|v| Value::new_attr(v.as_str())).collect()
                     }
-                    "uuid" => {
+                    "uuid" | "domain_uuid" => {
                         vs.into_iter().map(|v| Value::new_uuids(v.as_str())
                             .unwrap_or_else(|| {
                                 warn!("WARNING: Allowing syntax incorrect attribute to be presented UTF8 string");

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -1279,9 +1279,7 @@ impl<VALID, STATE> Entry<VALID, STATE> {
 
     pub(crate) fn generate_spn(&self, domain_name: &str) -> Option<Value> {
         self.get_ava_single_str("name")
-            .and_then(|name| {
-                Some(Value::new_spn_str(name, domain_name))
-            })
+            .and_then(|name| Some(Value::new_spn_str(name, domain_name)))
     }
 
     pub fn attribute_pres(&self, attr: &str) -> bool {

--- a/kanidmd/src/lib/entry.rs
+++ b/kanidmd/src/lib/entry.rs
@@ -1036,7 +1036,6 @@ impl<STATE> Entry<EntryValid, STATE> {
     pub fn get_uuid(&self) -> &Uuid {
         &self.valid.uuid
     }
-
 }
 
 impl Entry<EntryReduced, EntryCommitted> {

--- a/kanidmd/src/lib/event.rs
+++ b/kanidmd/src/lib/event.rs
@@ -2,7 +2,7 @@ use crate::audit::AuditScope;
 use crate::entry::{Entry, EntryCommitted, EntryInvalid, EntryNew, EntryReduced, EntryValid};
 use crate::filter::{Filter, FilterInvalid, FilterValid};
 use crate::schema::SchemaTransaction;
-use crate::value::{PartialValue};
+use crate::value::PartialValue;
 use kanidm_proto::v1::Entry as ProtoEntry;
 use kanidm_proto::v1::ModifyList as ProtoModifyList;
 use kanidm_proto::v1::{

--- a/kanidmd/src/lib/event.rs
+++ b/kanidmd/src/lib/event.rs
@@ -2,7 +2,7 @@ use crate::audit::AuditScope;
 use crate::entry::{Entry, EntryCommitted, EntryInvalid, EntryNew, EntryReduced, EntryValid};
 use crate::filter::{Filter, FilterInvalid, FilterValid};
 use crate::schema::SchemaTransaction;
-use crate::value::PartialValue;
+use crate::value::{PartialValue};
 use kanidm_proto::v1::Entry as ProtoEntry;
 use kanidm_proto::v1::ModifyList as ProtoModifyList;
 use kanidm_proto::v1::{

--- a/kanidmd/src/lib/plugins/domain.rs
+++ b/kanidmd/src/lib/plugins/domain.rs
@@ -91,7 +91,22 @@ mod tests {
     }
 
     #[test]
+    fn test_domain_ssid_change() {
+        // Test we can change domain_ssid as admin. This is mainly an ACP check.
+        unimplemented!();
+    }
+
+    #[test]
     fn test_domain_name_change_spn_regen() {
+        // get the current domain name
+
+        // check the spn on admin is admin@<initial domain>
+
+        // trigger the domain_name change (this will be a cli option to the server
+        // in the final version), but it will still call the same qs function to perform the
+        // change.
+
+        // check the spn on admin is admin@<new domain>
         unimplemented!();
     }
 }

--- a/kanidmd/src/lib/plugins/domain.rs
+++ b/kanidmd/src/lib/plugins/domain.rs
@@ -1,0 +1,92 @@
+// Manage and generate domain uuid's and/or trust related domain
+// management.
+
+// The primary point of this is to generate a unique domain UUID on startup
+// which is importart for management of the replication topo and trust
+// relationships.
+use crate::plugins::Plugin;
+
+use crate::audit::AuditScope;
+use crate::entry::{Entry, EntryInvalid, EntryNew};
+use crate::event::CreateEvent;
+use crate::server::QueryServerWriteTransaction;
+use crate::value::{PartialValue, Value};
+use kanidm_proto::v1::OperationError;
+
+use uuid::Uuid;
+
+lazy_static! {
+    static ref PVCLASS_DOMAIN_INFO: PartialValue = PartialValue::new_class("domain_info");
+}
+
+pub struct Domain {}
+
+impl Plugin for Domain {
+    fn id() -> &'static str {
+        "plugin_domain"
+    }
+
+    fn pre_create_transform(
+        au: &mut AuditScope,
+        _qs: &mut QueryServerWriteTransaction,
+        cand: &mut Vec<Entry<EntryInvalid, EntryNew>>,
+        _ce: &CreateEvent,
+    ) -> Result<(), OperationError> {
+        audit_log!(au, "Entering base pre_create_transform");
+        cand.iter_mut().for_each(|e| {
+            audit_log!(au, "{:?}", e);
+            if e.attribute_value_pres("class", &PVCLASS_DOMAIN_INFO)
+                && !e.attribute_pres("domain_uuid")
+            {
+                let u = Value::new_uuid(Uuid::new_v4());
+                e.set_avas("domain_uuid", vec![u]);
+                audit_log!(au, "Applying uuid transform");
+            }
+            audit_log!(au, "{:?}", e);
+        });
+        audit_log!(au, "Ending base pre_create_transform");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::entry::{Entry, EntryInvalid, EntryNew};
+    use crate::server::{QueryServerTransaction, QueryServerWriteTransaction};
+    use uuid::Uuid;
+    // test we can create and generate the id
+    #[test]
+    fn test_domain_generate_uuid() {
+        let preload = vec![];
+        let e: Entry<EntryInvalid, EntryNew> = Entry::unsafe_from_entry_str(
+            r#"{
+            "attrs": {
+                "class": ["domain_info", "system"],
+                "name": ["domain_example.net.au"],
+                "uuid": ["96fd1112-28bc-48ae-9dda-5acb4719aaba"],
+                "description": ["Demonstration of a remote domain's info being created for uuid generaiton"],
+                "domain_name": ["example.net.au"],
+                "domain_ssid": ["Example_Wifi"]
+            }
+        }"#,
+        );
+        let create = vec![e];
+
+        run_create_test!(
+            Ok(()),
+            preload,
+            create,
+            None,
+            |au, qs_write: &QueryServerWriteTransaction| {
+                // Check that a uuid was added?
+                let e = qs_write
+                    .internal_search_uuid(
+                        au,
+                        &Uuid::parse_str("96fd1112-28bc-48ae-9dda-5acb4719aaba").unwrap(),
+                    )
+                    .unwrap();
+                assert!(e.get_ava("domain_uuid").is_some());
+            }
+        );
+    }
+}

--- a/kanidmd/src/lib/plugins/domain.rs
+++ b/kanidmd/src/lib/plugins/domain.rs
@@ -89,24 +89,4 @@ mod tests {
             }
         );
     }
-
-    #[test]
-    fn test_domain_ssid_change() {
-        // Test we can change domain_ssid as admin. This is mainly an ACP check.
-        unimplemented!();
-    }
-
-    #[test]
-    fn test_domain_name_change_spn_regen() {
-        // get the current domain name
-
-        // check the spn on admin is admin@<initial domain>
-
-        // trigger the domain_name change (this will be a cli option to the server
-        // in the final version), but it will still call the same qs function to perform the
-        // change.
-
-        // check the spn on admin is admin@<new domain>
-        unimplemented!();
-    }
 }

--- a/kanidmd/src/lib/plugins/domain.rs
+++ b/kanidmd/src/lib/plugins/domain.rs
@@ -34,15 +34,14 @@ impl Plugin for Domain {
     ) -> Result<(), OperationError> {
         audit_log!(au, "Entering base pre_create_transform");
         cand.iter_mut().for_each(|e| {
-            audit_log!(au, "{:?}", e);
             if e.attribute_value_pres("class", &PVCLASS_DOMAIN_INFO)
                 && !e.attribute_pres("domain_uuid")
             {
                 let u = Value::new_uuid(Uuid::new_v4());
                 e.set_avas("domain_uuid", vec![u]);
-                audit_log!(au, "Applying uuid transform");
+                audit_log!(au, "plugin_domain: Applying uuid transform");
+                audit_log!(au, "{:?}", e);
             }
-            audit_log!(au, "{:?}", e);
         });
         audit_log!(au, "Ending base pre_create_transform");
         Ok(())

--- a/kanidmd/src/lib/plugins/domain.rs
+++ b/kanidmd/src/lib/plugins/domain.rs
@@ -89,4 +89,9 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn test_domain_name_change_spn_regen() {
+        unimplemented!();
+    }
 }

--- a/kanidmd/src/lib/plugins/mod.rs
+++ b/kanidmd/src/lib/plugins/mod.rs
@@ -343,7 +343,9 @@ impl Plugins {
         audit_segment!(au, || {
             let res =
                 run_post_modify_plugin!(au, qs, pre_cand, cand, me, refint::ReferentialIntegrity)
-                    .and_then(|_| run_post_modify_plugin!(au, qs, pre_cand, cand, me, memberof::MemberOf))
+                    .and_then(|_| {
+                        run_post_modify_plugin!(au, qs, pre_cand, cand, me, memberof::MemberOf)
+                    })
                     .and_then(|_| run_post_modify_plugin!(au, qs, pre_cand, cand, me, spn::Spn));
             res
         })

--- a/kanidmd/src/lib/plugins/mod.rs
+++ b/kanidmd/src/lib/plugins/mod.rs
@@ -282,6 +282,7 @@ impl Plugins {
         audit_segment!(au, || {
             let res = run_pre_create_transform_plugin!(au, qs, cand, ce, base::Base)
                 .and_then(|_| run_pre_create_transform_plugin!(au, qs, cand, ce, domain::Domain))
+                .and_then(|_| run_pre_create_transform_plugin!(au, qs, cand, ce, spn::Spn))
                 .and_then(|_| {
                     run_pre_create_transform_plugin!(au, qs, cand, ce, attrunique::AttrUnique)
                 });
@@ -325,6 +326,7 @@ impl Plugins {
         audit_segment!(au, || {
             let res = run_pre_modify_plugin!(au, qs, cand, me, protected::Protected)
                 .and_then(|_| run_pre_modify_plugin!(au, qs, cand, me, base::Base))
+                .and_then(|_| run_pre_modify_plugin!(au, qs, cand, me, spn::Spn))
                 .and_then(|_| run_pre_modify_plugin!(au, qs, cand, me, attrunique::AttrUnique));
 
             res
@@ -341,10 +343,8 @@ impl Plugins {
         audit_segment!(au, || {
             let res =
                 run_post_modify_plugin!(au, qs, pre_cand, cand, me, refint::ReferentialIntegrity)
-                    .and_then(|_| {
-                        run_post_modify_plugin!(au, qs, pre_cand, cand, me, memberof::MemberOf)
-                    });
-
+                    .and_then(|_| run_post_modify_plugin!(au, qs, pre_cand, cand, me, memberof::MemberOf))
+                    .and_then(|_| run_post_modify_plugin!(au, qs, pre_cand, cand, me, spn::Spn));
             res
         })
     }
@@ -384,6 +384,7 @@ impl Plugins {
         run_verify_plugin!(au, qs, &mut results, attrunique::AttrUnique);
         run_verify_plugin!(au, qs, &mut results, refint::ReferentialIntegrity);
         run_verify_plugin!(au, qs, &mut results, memberof::MemberOf);
+        run_verify_plugin!(au, qs, &mut results, spn::Spn);
         results
     }
 }

--- a/kanidmd/src/lib/plugins/mod.rs
+++ b/kanidmd/src/lib/plugins/mod.rs
@@ -9,11 +9,13 @@ mod macros;
 
 mod attrunique;
 mod base;
+mod domain;
 mod failure;
 mod memberof;
 mod protected;
 mod recycle;
 mod refint;
+mod spn;
 
 trait Plugin {
     fn id() -> &'static str;
@@ -278,11 +280,11 @@ impl Plugins {
         ce: &CreateEvent,
     ) -> Result<(), OperationError> {
         audit_segment!(au, || {
-            let res =
-                run_pre_create_transform_plugin!(au, qs, cand, ce, base::Base).and_then(|_| {
+            let res = run_pre_create_transform_plugin!(au, qs, cand, ce, base::Base)
+                .and_then(|_| run_pre_create_transform_plugin!(au, qs, cand, ce, domain::Domain))
+                .and_then(|_| {
                     run_pre_create_transform_plugin!(au, qs, cand, ce, attrunique::AttrUnique)
                 });
-
             res
         })
     }

--- a/kanidmd/src/lib/plugins/protected.rs
+++ b/kanidmd/src/lib/plugins/protected.rs
@@ -20,8 +20,13 @@ pub struct Protected {}
 lazy_static! {
     static ref ALLOWED_ATTRS: HashSet<&'static str> = {
         let mut m = HashSet::new();
+        // Allow modification of some schema class types to allow local extension
+        // of schema types.
         m.insert("must");
         m.insert("may");
+        // Allow modification of some domain info types for local configuration.
+        m.insert("domain_name");
+        m.insert("domain_ssid");
         m
     };
     static ref PVCLASS_SYSTEM: PartialValue = PartialValue::new_class("system");
@@ -371,5 +376,23 @@ mod tests {
             Some(JSON_ADMIN_V1),
             |_, _| {}
         );
+    }
+
+    #[test]
+    fn test_modify_domain() {
+        // Can edit *my* domain_ssid and domain_name
+        // can not delete any domain_info type
+        unimplemented!();
+    }
+
+    #[test]
+    fn test_ext_create_domain() {
+        // can not add a domain_info type
+        unimplemented!();
+    }
+
+    #[test]
+    fn test_delete_domain() {
+        unimplemented!();
     }
 }

--- a/kanidmd/src/lib/plugins/protected.rs
+++ b/kanidmd/src/lib/plugins/protected.rs
@@ -25,7 +25,6 @@ lazy_static! {
         m.insert("must");
         m.insert("may");
         // Allow modification of some domain info types for local configuration.
-        m.insert("domain_name");
         m.insert("domain_ssid");
         m
     };
@@ -414,9 +413,7 @@ mod tests {
                 PartialValue::new_iutf8s("domain_example.net.au")
             )),
             modlist!([
-                m_purge("domain_name"),
                 m_purge("domain_ssid"),
-                m_pres("domain_name", &Value::new_iutf8s("example.org.au")),
                 m_pres("domain_ssid", &Value::new_utf8s("NewExampleWifi")),
             ]),
             Some(JSON_ADMIN_V1),

--- a/kanidmd/src/lib/plugins/protected.rs
+++ b/kanidmd/src/lib/plugins/protected.rs
@@ -32,9 +32,11 @@ lazy_static! {
     static ref PVCLASS_SYSTEM: PartialValue = PartialValue::new_class("system");
     static ref PVCLASS_TOMBSTONE: PartialValue = PartialValue::new_class("tombstone");
     static ref PVCLASS_RECYCLED: PartialValue = PartialValue::new_class("recycled");
+    static ref PVCLASS_DOMAIN_INFO: PartialValue = PartialValue::new_class("domain_info");
     static ref VCLASS_SYSTEM: Value = Value::new_class("system");
     static ref VCLASS_TOMBSTONE: Value = Value::new_class("tombstone");
     static ref VCLASS_RECYCLED: Value = Value::new_class("recycled");
+    static ref VCLASS_DOMAIN_INFO: Value = Value::new_class("domain_info");
 }
 
 impl Plugin for Protected {
@@ -61,6 +63,7 @@ impl Plugin for Protected {
             Err(_) => acc,
             Ok(_) => {
                 if cand.attribute_value_pres("class", &PVCLASS_SYSTEM)
+                    || cand.attribute_value_pres("class", &PVCLASS_DOMAIN_INFO)
                     || cand.attribute_value_pres("class", &PVCLASS_TOMBSTONE)
                     || cand.attribute_value_pres("class", &PVCLASS_RECYCLED)
                 {
@@ -86,7 +89,7 @@ impl Plugin for Protected {
             );
             return Ok(());
         }
-        // Prevent adding class: system, tombstone, or recycled.
+        // Prevent adding class: system, domain_info, tombstone, or recycled.
         me.modlist.iter().fold(Ok(()), |acc, m| {
             if acc.is_err() {
                 acc
@@ -96,6 +99,7 @@ impl Plugin for Protected {
                         // TODO: Can we avoid this clone?
                         if a == "class"
                             && (v == &(VCLASS_SYSTEM.clone())
+                                || v == &(VCLASS_DOMAIN_INFO.clone())
                                 || v == &(VCLASS_TOMBSTONE.clone())
                                 || v == &(VCLASS_RECYCLED.clone()))
                         {
@@ -109,7 +113,8 @@ impl Plugin for Protected {
             }
         })?;
 
-        // HARD block mods on tombstone or recycle.
+        // HARD block mods on tombstone or recycle. We soft block on the rest as they may
+        // have some allowed attrs.
         cand.iter().fold(Ok(()), |acc, cand| match acc {
             Err(_) => acc,
             Ok(_) => {
@@ -128,6 +133,8 @@ impl Plugin for Protected {
             if acc {
                 acc
             } else {
+                // We don't need to check for domain info here because domain_info has a class
+                // system also. We just need to block it from being created.
                 c.attribute_value_pres("class", &PVCLASS_SYSTEM)
             }
         });
@@ -176,6 +183,7 @@ impl Plugin for Protected {
             Err(_) => acc,
             Ok(_) => {
                 if cand.attribute_value_pres("class", &PVCLASS_SYSTEM)
+                    || cand.attribute_value_pres("class", &PVCLASS_DOMAIN_INFO)
                     || cand.attribute_value_pres("class", &PVCLASS_TOMBSTONE)
                     || cand.attribute_value_pres("class", &PVCLASS_RECYCLED)
                 {
@@ -209,7 +217,7 @@ mod tests {
             ],
             "name": ["idm_admins_acp_allow_all_test"],
             "uuid": ["bb18f746-a409-497d-928c-5455d4aef4f7"],
-            "description": ["Builtin IDM Administrators Access Controls."],
+            "description": ["Builtin IDM Administrators Access Controls for TESTING."],
             "acp_enable": ["true"],
             "acp_receiver": [
                 "{\"Eq\":[\"uuid\",\"00000000-0000-0000-0000-000000000000\"]}"
@@ -218,11 +226,11 @@ mod tests {
                 "{\"Pres\":\"class\"}"
             ],
             "acp_search_attr": ["name", "class", "uuid", "classname", "attributename"],
-            "acp_modify_class": ["system"],
-            "acp_modify_removedattr": ["class", "displayname", "may", "must"],
-            "acp_modify_presentattr": ["class", "displayname", "may", "must"],
-            "acp_create_class": ["object", "person", "system"],
-            "acp_create_attr": ["name", "class", "description", "displayname"]
+            "acp_modify_class": ["system", "domain_info"],
+            "acp_modify_removedattr": ["class", "displayname", "may", "must", "domain_name", "domain_ssid"],
+            "acp_modify_presentattr": ["class", "displayname", "may", "must", "domain_name", "domain_ssid"],
+            "acp_create_class": ["object", "person", "system", "domain_info"],
+            "acp_create_attr": ["name", "class", "description", "displayname", "domain_name", "domain_ssid", "uuid"]
         }
     }"#;
 
@@ -381,18 +389,97 @@ mod tests {
     #[test]
     fn test_modify_domain() {
         // Can edit *my* domain_ssid and domain_name
-        // can not delete any domain_info type
-        unimplemented!();
+        let acp: Entry<EntryInvalid, EntryNew> = Entry::unsafe_from_entry_str(JSON_ADMIN_ALLOW_ALL);
+        // Show that adding a system class is denied
+        let e: Entry<EntryInvalid, EntryNew> = Entry::unsafe_from_entry_str(
+            r#"{
+            "attrs": {
+                "class": ["domain_info"],
+                "name": ["domain_example.net.au"],
+                "uuid": ["96fd1112-28bc-48ae-9dda-5acb4719aaba"],
+                "description": ["Demonstration of a remote domain's info being created for uuid generaiton"],
+                "domain_name": ["example.net.au"],
+                "domain_ssid": ["Example_Wifi"]
+            }
+        }"#,
+        );
+
+        let preload = vec![acp, e.clone()];
+
+        run_modify_test!(
+            Ok(()),
+            preload,
+            filter!(f_eq(
+                "name",
+                PartialValue::new_iutf8s("domain_example.net.au")
+            )),
+            modlist!([
+                m_purge("domain_name"),
+                m_purge("domain_ssid"),
+                m_pres("domain_name", &Value::new_iutf8s("example.org.au")),
+                m_pres("domain_ssid", &Value::new_utf8s("NewExampleWifi")),
+            ]),
+            Some(JSON_ADMIN_V1),
+            |_, _| {}
+        );
     }
 
     #[test]
     fn test_ext_create_domain() {
-        // can not add a domain_info type
-        unimplemented!();
+        // can not add a domain_info type - note the lack of class: system
+        let acp: Entry<EntryInvalid, EntryNew> = Entry::unsafe_from_entry_str(JSON_ADMIN_ALLOW_ALL);
+        let preload = vec![acp];
+        let e: Entry<EntryInvalid, EntryNew> = Entry::unsafe_from_entry_str(
+            r#"{
+            "attrs": {
+                "class": ["domain_info"],
+                "name": ["domain_example.net.au"],
+                "uuid": ["96fd1112-28bc-48ae-9dda-5acb4719aaba"],
+                "description": ["Demonstration of a remote domain's info being created for uuid generaiton"],
+                "domain_name": ["example.net.au"],
+                "domain_ssid": ["Example_Wifi"]
+            }
+        }"#,
+        );
+        let create = vec![e];
+
+        run_create_test!(
+            Err(OperationError::SystemProtectedObject),
+            preload,
+            create,
+            Some(JSON_ADMIN_V1),
+            |_, _| {}
+        );
     }
 
     #[test]
     fn test_delete_domain() {
-        unimplemented!();
+        let acp: Entry<EntryInvalid, EntryNew> = Entry::unsafe_from_entry_str(JSON_ADMIN_ALLOW_ALL);
+        // On the real thing we have a class: system, but to prove the point ...
+        let e: Entry<EntryInvalid, EntryNew> = Entry::unsafe_from_entry_str(
+            r#"{
+            "attrs": {
+                "class": ["domain_info"],
+                "name": ["domain_example.net.au"],
+                "uuid": ["96fd1112-28bc-48ae-9dda-5acb4719aaba"],
+                "description": ["Demonstration of a remote domain's info being created for uuid generaiton"],
+                "domain_name": ["example.net.au"],
+                "domain_ssid": ["Example_Wifi"]
+            }
+        }"#,
+        );
+
+        let preload = vec![acp, e.clone()];
+
+        run_delete_test!(
+            Err(OperationError::SystemProtectedObject),
+            preload,
+            filter!(f_eq(
+                "name",
+                PartialValue::new_iutf8s("domain_example.net.au")
+            )),
+            Some(JSON_ADMIN_V1),
+            |_, _| {}
+        );
     }
 }

--- a/kanidmd/src/lib/plugins/spn.rs
+++ b/kanidmd/src/lib/plugins/spn.rs
@@ -1,1 +1,109 @@
-// Generate and manage spn's for all entries in the domain.
+// Generate and manage spn's for all entries in the domain. Also deals with
+// the infrequent - but possible - case where a domain is renamed.
+use crate::plugins::Plugin;
+
+use crate::audit::AuditScope;
+use crate::entry::{Entry, EntryInvalid, EntryValid, EntryNew, EntryCommitted};
+use crate::event::{CreateEvent, ModifyEvent};
+use crate::server::{QueryServerWriteTransaction, QueryServerReadTransaction};
+// use crate::value::{PartialValue, Value};
+use kanidm_proto::v1::{OperationError, ConsistencyError};
+
+pub struct Spn {}
+
+impl Plugin for Spn {
+    fn id() -> &'static str {
+        "plugin_spn"
+    }
+
+    // hook on pre-create and modify to generate / validate.
+    fn pre_create_transform(
+        _au: &mut AuditScope,
+        _qs: &mut QueryServerWriteTransaction,
+        _cand: &mut Vec<Entry<EntryInvalid, EntryNew>>,
+        _ce: &CreateEvent,
+    ) -> Result<(), OperationError> {
+        // Always generate the spn and set it. Why? Because the effort
+        // needed to validate is the same as generation, so we may as well
+        // just generate and set blindly when required.
+        unimplemented!();
+    }
+
+    fn pre_modify(
+        _au: &mut AuditScope,
+        _qs: &mut QueryServerWriteTransaction,
+        _cand: &mut Vec<Entry<EntryInvalid, EntryCommitted>>,
+        _me: &ModifyEvent,
+    ) -> Result<(), OperationError> {
+        // Always generate and set *if* spn was an attribute on any of the mod
+        // list events.
+        unimplemented!();
+    }
+
+    fn post_modify(
+        _au: &mut AuditScope,
+        _qs: &mut QueryServerWriteTransaction,
+        // List of what we modified that was valid?
+        _pre_cand: &Vec<Entry<EntryValid, EntryCommitted>>,
+        _cand: &Vec<Entry<EntryValid, EntryCommitted>>,
+        _ce: &ModifyEvent,
+    ) -> Result<(), OperationError> {
+        // On modify, if changing domain_name on UUID_DOMAIN_INFO
+        //    trigger the spn regen ... which is expensive. Future
+        // todo will be a way to batch this I guess ...
+        unimplemented!();
+    }
+
+    fn verify(
+        _au: &mut AuditScope,
+        _qs: &QueryServerReadTransaction,
+    ) -> Vec<Result<(), ConsistencyError>> {
+        // Verify that all items with spn's have valid spns.
+        //   We need to consider the case that an item has a different origin domain too,
+        // so we should be able to verify that *those* spns validate to the trusted domain info
+        // we have been sent also. It's not up to use to generate those though ...
+        // let mut r = Vec::new();
+        unimplemented!();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_spn_generate_create() {
+        // on create don't provide
+        unimplemented!();
+    }
+
+    #[test]
+    fn test_spn_generate_modify() {
+        // on a purge of the spen, generate it.
+        unimplemented!();
+    }
+
+    #[test]
+    fn test_spn_validate_create() {
+        // on create providing invalid spn, we over-write it.
+        unimplemented!();
+    }
+
+    #[test]
+    fn test_spn_validate_modify() {
+        // On modify (removed/present) of the spn, just regenerate it.
+        unimplemented!();
+    }
+
+    #[test]
+    fn test_spn_regen_domain_rename() {
+        // get the current domain name
+
+        // check the spn on admin is admin@<initial domain>
+
+        // trigger the domain_name change (this will be a cli option to the server
+        // in the final version), but it will still call the same qs function to perform the
+        // change.
+
+        // check the spn on admin is admin@<new domain>
+        unimplemented!();
+    }
+}

--- a/kanidmd/src/lib/plugins/spn.rs
+++ b/kanidmd/src/lib/plugins/spn.rs
@@ -5,11 +5,60 @@ use crate::plugins::Plugin;
 use crate::audit::AuditScope;
 use crate::entry::{Entry, EntryCommitted, EntryInvalid, EntryNew, EntryValid};
 use crate::event::{CreateEvent, ModifyEvent};
-use crate::server::{QueryServerReadTransaction, QueryServerWriteTransaction};
+use crate::server::{QueryServerReadTransaction, QueryServerWriteTransaction, QueryServerTransaction};
+use crate::constants::UUID_DOMAIN_INFO;
+use crate::value::{PartialValue};
 // use crate::value::{PartialValue, Value};
 use kanidm_proto::v1::{ConsistencyError, OperationError};
+use uuid::Uuid;
 
 pub struct Spn {}
+
+lazy_static! {
+    static ref UUID_DOMAIN_INFO_T: Uuid = Uuid::parse_str(UUID_DOMAIN_INFO).expect("Unable to parse constant UUID_DOMAIN_INFO");
+    static ref CLASS_GROUP: PartialValue = PartialValue::new_iutf8s("group");
+    static ref CLASS_ACCOUNT: PartialValue = PartialValue::new_iutf8s("account");
+}
+
+impl Spn {
+    fn get_domain_name(
+        au: &mut AuditScope,
+        qs: &mut QueryServerWriteTransaction,
+    ) -> Result<String, OperationError> {
+        qs
+            .internal_search_uuid(
+                au,
+                &UUID_DOMAIN_INFO_T
+            )
+            .and_then(|e| {
+                e.get_ava_single_string("domain_name")
+                    .ok_or(OperationError::InvalidEntryState)
+            })
+            .map_err(|e| {
+                audit_log!(au, "Error getting domain name -> {:?}", e);
+                e
+            })
+    }
+
+    fn get_domain_name_ro(
+        au: &mut AuditScope,
+        qs: &QueryServerReadTransaction,
+    ) -> Result<String, OperationError> {
+        qs
+            .internal_search_uuid(
+                au,
+                &UUID_DOMAIN_INFO_T
+            )
+            .and_then(|e| {
+                e.get_ava_single_string("domain_name")
+                    .ok_or(OperationError::InvalidEntryState)
+            })
+            .map_err(|e| {
+                audit_log!(au, "Error getting domain name -> {:?}", e);
+                e
+            })
+    }
+}
 
 impl Plugin for Spn {
     fn id() -> &'static str {
@@ -18,26 +67,74 @@ impl Plugin for Spn {
 
     // hook on pre-create and modify to generate / validate.
     fn pre_create_transform(
-        _au: &mut AuditScope,
-        _qs: &mut QueryServerWriteTransaction,
-        _cand: &mut Vec<Entry<EntryInvalid, EntryNew>>,
+        au: &mut AuditScope,
+        qs: &mut QueryServerWriteTransaction,
+        cand: &mut Vec<Entry<EntryInvalid, EntryNew>>,
         _ce: &CreateEvent,
     ) -> Result<(), OperationError> {
         // Always generate the spn and set it. Why? Because the effort
         // needed to validate is the same as generation, so we may as well
         // just generate and set blindly when required.
-        unimplemented!();
+
+        // TODO: Should we work out what classes dynamically from schema into a filter?
+        let mut domain_name: Option<String> = None;
+
+        for e in cand.iter_mut() {
+            if e.attribute_value_pres("class", &CLASS_GROUP)
+                || e.attribute_value_pres("class", &CLASS_ACCOUNT) {
+
+                if domain_name.is_none() {
+                    domain_name = Some(Self::get_domain_name(au, qs)?);
+                }
+
+                // It should be impossible to hit this expect as the is_none case should cause it to be replaced above.
+                let some_domain_name = domain_name.as_ref().expect("Domain name option memory corruption has occured.");
+
+                let spn = e.generate_spn(some_domain_name.as_str())
+                    .ok_or(OperationError::InvalidEntryState)
+                    .map_err(|e| {
+                        audit_log!(au, "Account or group missing name, unable to generate spn!? {:?}", e);
+                        e
+                    })?;
+                audit_log!(au, "plugin_spn: set spn to {:?}", spn);
+                e.set_avas("spn", vec![spn]);
+            }
+        }
+        Ok(())
     }
 
     fn pre_modify(
-        _au: &mut AuditScope,
-        _qs: &mut QueryServerWriteTransaction,
-        _cand: &mut Vec<Entry<EntryInvalid, EntryCommitted>>,
+        au: &mut AuditScope,
+        qs: &mut QueryServerWriteTransaction,
+        cand: &mut Vec<Entry<EntryInvalid, EntryCommitted>>,
         _me: &ModifyEvent,
     ) -> Result<(), OperationError> {
         // Always generate and set *if* spn was an attribute on any of the mod
         // list events.
-        unimplemented!();
+        let mut domain_name: Option<String> = None;
+
+        for e in cand.iter_mut() {
+            if e.attribute_value_pres("class", &CLASS_GROUP)
+                || e.attribute_value_pres("class", &CLASS_ACCOUNT) {
+
+                if domain_name.is_none() {
+                    domain_name = Some(Self::get_domain_name(au, qs)?);
+                }
+
+                // It should be impossible to hit this expect as the is_none case should cause it to be replaced above.
+                let some_domain_name = domain_name.as_ref().expect("Domain name option memory corruption has occured.");
+
+                let spn = e.generate_spn(some_domain_name.as_str())
+                    .ok_or(OperationError::InvalidEntryState)
+                    .map_err(|e| {
+                        audit_log!(au, "Account or group missing name, unable to generate spn!? {:?}", e);
+                        e
+                    })?;
+                audit_log!(au, "plugin_spn: set spn to {:?}", spn);
+                e.set_avas("spn", vec![spn]);
+            }
+        }
+        Ok(())
     }
 
     fn post_modify(
@@ -51,46 +148,204 @@ impl Plugin for Spn {
         // On modify, if changing domain_name on UUID_DOMAIN_INFO
         //    trigger the spn regen ... which is expensive. Future
         // todo will be a way to batch this I guess ...
-        unimplemented!();
+        Ok(())
     }
 
     fn verify(
-        _au: &mut AuditScope,
-        _qs: &QueryServerReadTransaction,
+        au: &mut AuditScope,
+        qs: &QueryServerReadTransaction,
     ) -> Vec<Result<(), ConsistencyError>> {
         // Verify that all items with spn's have valid spns.
         //   We need to consider the case that an item has a different origin domain too,
         // so we should be able to verify that *those* spns validate to the trusted domain info
         // we have been sent also. It's not up to use to generate those though ...
-        // let mut r = Vec::new();
-        unimplemented!();
+
+        let domain_name = match Self::get_domain_name_ro(au, qs)
+            .map_err(|_| Err(ConsistencyError::QueryServerSearchFailure))
+        {
+            Ok(dn) => dn,
+            Err(e) => return vec![e],
+        };
+
+        let filt_in = filter!(f_and!([
+            f_eq("class", PartialValue::new_class("group")),
+            f_eq("class", PartialValue::new_class("account"))
+        ]));
+
+        let all_cand = match qs
+            .internal_search(au, filt_in)
+            .map_err(|_| Err(ConsistencyError::QueryServerSearchFailure))
+        {
+            Ok(all_cand) => all_cand,
+            Err(e) => return vec![e],
+        };
+
+        let mut r = Vec::new();
+
+        for e in all_cand {
+            let g_spn = match e.generate_spn(domain_name.as_str()) {
+                Some(s) => s,
+                None => {
+                        audit_log!(
+                            au,
+                            "Entry {:?} SPN could not be generated (missing name!?)",
+                            e.get_uuid()
+                        );
+                        debug_assert!(false);
+                        r.push(Err(ConsistencyError::InvalidSPN(e.get_id())));
+                        continue;
+                }
+            };
+            match e.get_ava_single("spn") {
+                Some(r_spn) => {
+                    audit_log!(au, "verify spn: s {:?} == ex {:?} ?", r_spn, g_spn);
+                    if *r_spn != g_spn {
+                        audit_log!(
+                            au,
+                            "Entry {:?} SPN does not match expected s {:?} != ex {:?}",
+                            e.get_uuid(), r_spn, g_spn,
+                        );
+                        debug_assert!(false);
+                        r.push(Err(ConsistencyError::InvalidSPN(e.get_id())))
+                    }
+                }
+                None => {
+                    audit_log!(
+                        au,
+                        "Entry {:?} does not contain an SPN",
+                        e.get_uuid(),
+                    );
+                    r.push(Err(ConsistencyError::InvalidSPN(e.get_id())))
+                }
+            }
+        }
+        r
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::entry::{Entry, EntryInvalid, EntryNew};
+    use crate::server::{QueryServerWriteTransaction};
+    use crate::value::{PartialValue, Value};
+
     #[test]
     fn test_spn_generate_create() {
         // on create don't provide
-        unimplemented!();
+        let e: Entry<EntryInvalid, EntryNew> = Entry::unsafe_from_entry_str(
+            r#"{
+            "valid": null,
+            "state": null,
+            "attrs": {
+                "class": ["account"],
+                "name": ["testperson"],
+                "description": ["testperson"],
+                "displayname": ["testperson"]
+            }
+        }"#,
+        );
+
+        let create = vec![e.clone()];
+        let preload = Vec::new();
+
+        run_create_test!(
+            Ok(()),
+            preload,
+            create,
+            None,
+            |_au, _qs_write: &QueryServerWriteTransaction| {}
+        );
+        // We don't need a validator due to the fn verify above.
     }
 
     #[test]
     fn test_spn_generate_modify() {
         // on a purge of the spen, generate it.
-        unimplemented!();
+        let e: Entry<EntryInvalid, EntryNew> = Entry::unsafe_from_entry_str(
+            r#"{
+            "valid": null,
+            "state": null,
+            "attrs": {
+                "class": ["account"],
+                "name": ["testperson"],
+                "description": ["testperson"],
+                "displayname": ["testperson"]
+            }
+        }"#,
+        );
+
+        let preload = vec![e];
+
+        run_modify_test!(
+            Ok(()),
+            preload,
+            filter!(f_eq("name", PartialValue::new_iutf8s("testperson"))),
+            modlist!([
+                m_purge("spn")
+            ]),
+            None,
+            |_, _| {}
+        );
     }
 
     #[test]
     fn test_spn_validate_create() {
         // on create providing invalid spn, we over-write it.
-        unimplemented!();
+        let e: Entry<EntryInvalid, EntryNew> = Entry::unsafe_from_entry_str(
+            r#"{
+            "valid": null,
+            "state": null,
+            "attrs": {
+                "class": ["account"],
+                "spn": ["testperson@invalid_domain.com"],
+                "name": ["testperson"],
+                "description": ["testperson"],
+                "displayname": ["testperson"]
+            }
+        }"#,
+        );
+
+        let create = vec![e.clone()];
+        let preload = Vec::new();
+
+        run_create_test!(
+            Ok(()),
+            preload,
+            create,
+            None,
+            |_au, _qs_write: &QueryServerWriteTransaction| {}
+        );
     }
 
     #[test]
     fn test_spn_validate_modify() {
         // On modify (removed/present) of the spn, just regenerate it.
-        unimplemented!();
+        let e: Entry<EntryInvalid, EntryNew> = Entry::unsafe_from_entry_str(
+            r#"{
+            "valid": null,
+            "state": null,
+            "attrs": {
+                "class": ["account"],
+                "name": ["testperson"],
+                "description": ["testperson"],
+                "displayname": ["testperson"]
+            }
+        }"#,
+        );
+
+        let preload = vec![e];
+
+        run_modify_test!(
+            Ok(()),
+            preload,
+            filter!(f_eq("name", PartialValue::new_iutf8s("testperson"))),
+            modlist!([
+                m_purge("spn"),
+                m_pres("spn", &Value::new_spn_str("invalid", "spn"))
+            ]),
+            None,
+            |_, _| {}
+        );
     }
 
     #[test]

--- a/kanidmd/src/lib/plugins/spn.rs
+++ b/kanidmd/src/lib/plugins/spn.rs
@@ -1,0 +1,1 @@
+// Generate and manage spn's for all entries in the domain.

--- a/kanidmd/src/lib/plugins/spn.rs
+++ b/kanidmd/src/lib/plugins/spn.rs
@@ -3,11 +3,11 @@
 use crate::plugins::Plugin;
 
 use crate::audit::AuditScope;
-use crate::entry::{Entry, EntryInvalid, EntryValid, EntryNew, EntryCommitted};
+use crate::entry::{Entry, EntryCommitted, EntryInvalid, EntryNew, EntryValid};
 use crate::event::{CreateEvent, ModifyEvent};
-use crate::server::{QueryServerWriteTransaction, QueryServerReadTransaction};
+use crate::server::{QueryServerReadTransaction, QueryServerWriteTransaction};
 // use crate::value::{PartialValue, Value};
-use kanidm_proto::v1::{OperationError, ConsistencyError};
+use kanidm_proto::v1::{ConsistencyError, OperationError};
 
 pub struct Spn {}
 

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -230,6 +230,14 @@ impl SchemaAttribute {
         }
     }
 
+    fn validate_spn(&self, v: &Value) -> Result<(), SchemaError> {
+        if v.is_spn() {
+            Ok(())
+        } else {
+            Err(SchemaError::InvalidAttributeSyntax)
+        }
+    }
+
     // TODO: There may be a difference between a value and a filter value on complex
     // types - IE a complex type may have multiple parts that are secret, but a filter
     // on that may only use a single tagged attribute for example.
@@ -246,6 +254,7 @@ impl SchemaAttribute {
             SyntaxType::CREDENTIAL => v.is_credential(),
             SyntaxType::RADIUS_UTF8STRING => v.is_radius_string(),
             SyntaxType::SSHKEY => v.is_sshkey(),
+            SyntaxType::SERVICE_PRINCIPLE_NAME => v.is_spn(),
         };
         if r {
             Ok(())
@@ -356,6 +365,13 @@ impl SchemaAttribute {
             SyntaxType::SSHKEY => ava.iter().fold(Ok(()), |acc, v| {
                 if acc.is_ok() {
                     self.validate_sshkey(v)
+                } else {
+                    acc
+                }
+            }),
+            SyntaxType::SERVICE_PRINCIPLE_NAME => ava.iter().fold(Ok(()), |acc, v| {
+                if acc.is_ok() {
+                    self.validate_spn(v)
                 } else {
                     acc
                 }

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -1047,7 +1047,7 @@ impl SchemaInner {
                     systemmust: vec![
                         String::from("version"),
                         // Needed when we implement principalnames?
-                        String::from("domain"),
+                        // String::from("domain"),
                         // String::from("hostname"),
                     ],
                     must: vec![],

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -593,7 +593,9 @@ impl SchemaInner {
                     name: String::from("spn"),
                     uuid: Uuid::parse_str(UUID_SCHEMA_ATTR_SPN)
                         .expect("unable to parse static uuid"),
-                    description: String::from("The service principle name of an object, unique across all domain trusts"),
+                    description: String::from(
+                        "The service principle name of an object, unique across all domain trusts",
+                    ),
                     multivalue: false,
                     unique: true,
                     index: vec![IndexType::EQUALITY],

--- a/kanidmd/src/lib/schema.rs
+++ b/kanidmd/src/lib/schema.rs
@@ -588,6 +588,19 @@ impl SchemaInner {
                 },
             );
             s.attributes.insert(
+                String::from("spn"),
+                SchemaAttribute {
+                    name: String::from("spn"),
+                    uuid: Uuid::parse_str(UUID_SCHEMA_ATTR_SPN)
+                        .expect("unable to parse static uuid"),
+                    description: String::from("The service principle name of an object, unique across all domain trusts"),
+                    multivalue: false,
+                    unique: true,
+                    index: vec![IndexType::EQUALITY],
+                    syntax: SyntaxType::SERVICE_PRINCIPLE_NAME,
+                },
+            );
+            s.attributes.insert(
                 String::from("attributename"),
                 SchemaAttribute {
                     name: String::from("attributename"),

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -843,13 +843,10 @@ impl Value {
     }
 
     pub fn new_spn_parse(v: &str) -> Option<Self> {
-        PartialValue::new_spn_s(v)
-            .map(|spn| {
-                Value {
-                    pv: spn,
-                    data: None,
-                }
-            })
+        PartialValue::new_spn_s(v).map(|spn| Value {
+            pv: spn,
+            data: None,
+        })
     }
 
     pub fn new_spn_str(n: &str, r: &str) -> Self {

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -87,6 +87,7 @@ pub enum SyntaxType {
     CREDENTIAL,
     RADIUS_UTF8STRING,
     SSHKEY,
+    SERVICE_PRINCIPLE_NAME,
 }
 
 impl TryFrom<&str> for SyntaxType {
@@ -106,6 +107,7 @@ impl TryFrom<&str> for SyntaxType {
             "CREDENTIAL" => Ok(SyntaxType::CREDENTIAL),
             "RADIUS_UTF8STRING" => Ok(SyntaxType::RADIUS_UTF8STRING),
             "SSHKEY" => Ok(SyntaxType::SSHKEY),
+            "SERVICE_PRINCIPLE_NAME" => Ok(SyntaxType::SERVICE_PRINCIPLE_NAME),
             _ => Err(()),
         }
     }
@@ -127,6 +129,7 @@ impl TryFrom<usize> for SyntaxType {
             8 => Ok(SyntaxType::CREDENTIAL),
             9 => Ok(SyntaxType::RADIUS_UTF8STRING),
             10 => Ok(SyntaxType::SSHKEY),
+            11 => Ok(SyntaxType::SERVICE_PRINCIPLE_NAME),
             _ => Err(()),
         }
     }
@@ -146,6 +149,7 @@ impl SyntaxType {
             SyntaxType::CREDENTIAL => "CREDENTIAL",
             SyntaxType::RADIUS_UTF8STRING => "RADIUS_UTF8STRING",
             SyntaxType::SSHKEY => "SSHKEY",
+            SyntaxType::SERVICE_PRINCIPLE_NAME => "SERVICE_PRINCIPLE_NAME",
         })
     }
 
@@ -162,6 +166,7 @@ impl SyntaxType {
             SyntaxType::CREDENTIAL => 8,
             SyntaxType::RADIUS_UTF8STRING => 9,
             SyntaxType::SSHKEY => 10,
+            SyntaxType::SERVICE_PRINCIPLE_NAME => 11,
         }
     }
 }
@@ -189,6 +194,7 @@ pub enum PartialValue {
     Cred(String),
     SshKey(String),
     RadiusCred,
+    Spn(String, String),
 }
 
 impl PartialValue {
@@ -1182,6 +1188,16 @@ mod tests {
             "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAeGW1P6Pc2rPq0XqbRaDKBcXZUPRklo",
         );
         assert!(!sk5.validate());
+    }
+
+    #[test]
+    fn test_value_spn() {
+        // Create an spn vale
+        // create an spn pv
+        // check it's indexing output
+        // check it can parse from name@realm
+        // check it can produce name@realm as str from the pv.
+        // check it validates the syntax
     }
 
     /*

--- a/kanidmd/src/lib/value.rs
+++ b/kanidmd/src/lib/value.rs
@@ -842,6 +842,16 @@ impl Value {
         }
     }
 
+    pub fn new_spn_parse(v: &str) -> Option<Self> {
+        PartialValue::new_spn_s(v)
+            .map(|spn| {
+                Value {
+                    pv: spn,
+                    data: None,
+                }
+            })
+    }
+
     pub fn new_spn_str(n: &str, r: &str) -> Self {
         Value {
             pv: PartialValue::new_spn_nrs(n, r),


### PR DESCRIPTION
Implements #127 and #125. This adds domain_info support, and spn types and generation. It also correctly handles domain renaming, and has tooling to support this. It "should" work on an upgrade, due to the correct bump of index version, but I plan to test this from a backup of my production instance soon. 

- [ x ] cargo fmt has been run
- [ x ] cargo test has been run and passes
- [ - ] design document included (if relevant)
