### PR TITLE
20191217 update 1.39 deps

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,16 @@
+
+* bump all cargo.toml versions
+* bump index version in constants
+* check for breaking db entry changes.
+
+* release kanidm_proto
+* release kanidmd/kanidm
+* release kanidm_client
+* release kanidm_tools
+
+* build kanidmd docker
+* build kanidm_radisud docker
+
+* vendor and release to build.opensuse.org
+
+

--- a/kanidm_client/Cargo.toml
+++ b/kanidm_client/Cargo.toml
@@ -3,12 +3,17 @@ name = "kanidm_client"
 version = "0.1.0"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2018"
+license = "MPL-2.0"
+description = "Kanidm Client Library"
+documentation = "https://docs.rs/kanidm_client/latest/kanidm_client/"
+homepage = "https://github.com/Firstyear/kanidm/"
+repostiory = "https://github.com/Firstyear/kanidm/"
 
 [dependencies]
 log = "0.4"
 env_logger = "0.6"
 reqwest = "0.9"
-kanidm_proto = { path = "../kanidm_proto" }
+kanidm_proto = { path = "../kanidm_proto", version = "0.1" }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
@@ -17,5 +22,5 @@ toml = "0.5"
 [dev-dependencies]
 tokio = "0.1"
 actix = "0.7"
-kanidm = { path = "../kanidmd" }
+kanidm = { path = "../kanidmd", version = "0.1" }
 futures = "0.1"

--- a/kanidm_proto/Cargo.toml
+++ b/kanidm_proto/Cargo.toml
@@ -3,6 +3,11 @@ name = "kanidm_proto"
 version = "0.1.0"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2018"
+license = "MPL-2.0"
+description = "Kanidm Protocol Bindings for serde"
+documentation = "https://docs.rs/kanidm_proto/latest/kanidm_proto/"
+homepage = "https://github.com/Firstyear/kanidm/"
+repostiory = "https://github.com/Firstyear/kanidm/"
 
 [dependencies]
 serde = "1.0"

--- a/kanidm_tools/Cargo.toml
+++ b/kanidm_tools/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2018"
 default-run = "kanidm"
+license = "MPL-2.0"
+description = "Kanidm Client Tools"
+documentation = "https://docs.rs/kanidm_tools/latest/kanidm_tools/"
+homepage = "https://github.com/Firstyear/kanidm/"
+repostiory = "https://github.com/Firstyear/kanidm/"
 
 [[bin]]
 name = "kanidm"
@@ -18,8 +23,8 @@ name = "kanidm_badlist_preprocess"
 path = "src/badlist_preprocess.rs"
 
 [dependencies]
-kanidm_client = { path = "../kanidm_client" }
-kanidm_proto = { path = "../kanidm_proto" }
+kanidm_client = { path = "../kanidm_client", version = "0.1" }
+kanidm_proto = { path = "../kanidm_proto", version = "0.1" }
 rpassword = "0.4"
 structopt = { version = "0.2", default-features = false }
 log = "0.4"

--- a/kanidmd/Cargo.toml
+++ b/kanidmd/Cargo.toml
@@ -6,6 +6,11 @@ version = "0.1.0"
 authors = ["William Brown <william@blackhats.net.au>"]
 # default-run = "kanidm_core"
 edition = "2018"
+license = "MPL-2.0"
+description = "Kanidm Server Library and Binary"
+documentation = "https://docs.rs/kanidm/latest/kanidm/"
+homepage = "https://github.com/Firstyear/kanidm/"
+repostiory = "https://github.com/Firstyear/kanidm/"
 
 [lib]
 name = "kanidm"
@@ -17,7 +22,7 @@ path = "src/server/main.rs"
 
 
 [dependencies]
-kanidm_proto = { path = "../kanidm_proto" }
+kanidm_proto = { path = "../kanidm_proto", version = "0.1" }
 
 actix = "0.7"
 actix-web = { version = "0.7", features = ["ssl"] }


### PR DESCRIPTION
Update to 1.39 + all deps update, and setup cargo.toml's for publishing to crates (to prevent domain/crate squatting). 

- [ x ] cargo fmt has been run
- [ - ] cargo test has been run and passes
- [ - ] design document included (if relevant)
